### PR TITLE
Fix travis build and emit canonical name for capitalized proto fields in messages.

### DIFF
--- a/src/ts/message.ts
+++ b/src/ts/message.ts
@@ -58,7 +58,7 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
       }
       existing.push(field);
     }
-    const snakeCaseName = field.getName();
+    const snakeCaseName = field.getName().toLowerCase();
     const camelCaseName = snakeToCamel(snakeCaseName);
     const withUppercase = uppercaseFirst(camelCaseName);
     const type = field.getType();

--- a/test/proto/examplecom/primitive_message_v2.proto
+++ b/test/proto/examplecom/primitive_message_v2.proto
@@ -34,4 +34,6 @@ message PrimitiveMessageV2 {
     optional bool opt_bool = 28;
     optional string opt_string = 29;
     optional bytes opt_bytes = 30;
+
+    optional int32 opt_NUMBER = 31;
 }

--- a/test/proto/examplecom/primitive_message_v3.proto
+++ b/test/proto/examplecom/primitive_message_v3.proto
@@ -18,4 +18,6 @@ message PrimitiveMessageV3 {
     bool my_bool = 13;
     string my_string = 14;
     bytes my_bytes = 15;
+
+    int32 my_NUMBER = 16;
 }

--- a/test/ts_test/generate.sh
+++ b/test/ts_test/generate.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
+#!/bin/bash -x
 
-rm -rf generated/
-mkdir -p generated/
+if [ -d generated ]
+then
+    rm -rf generated/
+fi
+mkdir generated
 
 protoc \
   --plugin=protoc-gen-ts=../../bin/protoc-gen-ts \

--- a/test/ts_test/package.json
+++ b/test/ts_test/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "generate": "rm -rf generated && ./generate.sh",
+    "generate": "./generate.sh",
     "build": "npm run generate && rm -rf ./build && tsc",
     "test": "mocha --require source-map-support/register ./build/src"
   }

--- a/test/ts_test/src/maps.ts
+++ b/test/ts_test/src/maps.ts
@@ -172,7 +172,7 @@ describe("maps", () => {
       const internalEnumsMap = parentMsg.getInternalEnumsMap();
       internalEnumsMap.set(123, InternalEnum.FIRST).set(456, InternalEnum.SECOND);
 
-      assert.deepEqual(parentMsg.toObject() as {
+      type mapType = {
         internalChildrenMap: Array<[string, {
           myString: string,
         }]>,
@@ -182,7 +182,9 @@ describe("maps", () => {
         internalEnumsMap: Array<[number, InternalEnum]>
         externalEnumsMap: Array<[number, ExternalEnum]>
         primitiveIntsMap: Array<[string, number]>
-      }, {
+      };
+      const actual = parentMsg.toObject() as mapType;
+      const expected: mapType = {
         externalEnumsMap: [],
         externalChildrenMap: [],
         internalEnumsMap: [
@@ -201,7 +203,8 @@ describe("maps", () => {
           ["first", 123],
           ["second", 456],
         ],
-      });
+      };
+      assert.deepEqual(actual, expected);
     });
   });
 });

--- a/test/ts_test/src/primitivesV2.ts
+++ b/test/ts_test/src/primitivesV2.ts
@@ -178,5 +178,10 @@ describe("proto2 - primitive", () => {
       assert.strictEqual(asObject.optString as undefined, undefined);
       assert.strictEqual(asObject.optBytes as string, "");
     });
+    it("should camelcase fully-capitalized field names", () => {
+      const msg = new PrimitiveMessageV2();
+      const asObject = msg.toObject();
+      assert.strictEqual("optNumber" in asObject, true);
+    });
   });
 });

--- a/test/ts_test/src/primitivesV3.ts
+++ b/test/ts_test/src/primitivesV3.ts
@@ -92,5 +92,10 @@ describe("proto3 - primitive", () => {
       assert.strictEqual(asObject.myString as string, "");
       assert.strictEqual(asObject.myBytes as (Uint8Array|string), "");
     });
+    it("should camelcase fully-capitalized field names", () => {
+      const msg = new PrimitiveMessageV3();
+      const asObject = msg.toObject();
+      assert.strictEqual("myNumber" in asObject, true);
+    });
   });
 });


### PR DESCRIPTION
This fixes #2 as well as updating tests so `npm test` passes on travis again.