### PR TITLE
Compile with bazel and rules_typescript

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+exports_files(["tsconfig.json"])
+
+# NOTE: this will move to node_modules/BUILD in a later release
+filegroup(
+    name = "node_modules",
+    srcs = glob([
+        "node_modules/**/*.js",
+        "node_modules/**/*.d.ts",
+        "node_modules/**/*.json",
+    ])
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,15 @@
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    url = "https://github.com/bazelbuild/rules_nodejs/archive/defc6449af919b7388e64467df27ceba95b4a33b.zip",
+    sha256 = "bbfc7372d92e23e36eabc2530ccfadb2534ec4e35bf51c20894c909895c2f6bb",
+    strip_prefix = "rules_nodejs-defc6449af919b7388e64467df27ceba95b4a33b",
+)
+
+load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+
+node_repositories(package_json = ["//:package.json"])
+
+local_repository(
+    name = "build_bazel_rules_typescript",
+    path = "node_modules/@bazel/typescript",
+)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/google-protobuf": "^3.2.4",
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.5",
+    "@bazel/typescript": "^0.0.10",
     "babel": "^6.5.2",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",

--- a/src/BUILD
+++ b/src/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility=["//visibility:public"])
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+
+ts_library(
+    name = "src",
+    srcs = glob([
+        "*.ts",
+        "js/*.ts",
+        "ts/*.ts",
+    ]),
+    deps = [],
+    tsconfig = "//:tsconfig.json",
+)


### PR DESCRIPTION
This is a work-in-progress to get `ts-protoc-gen` compiling with `rules_typescript`.  Not ready for merge.