### PR TITLE
service: set the boolean literal types explicitly

### DIFF
--- a/src/ts/fileDescriptorTSServices.ts
+++ b/src/ts/fileDescriptorTSServices.ts
@@ -46,8 +46,8 @@ export function printFileDescriptorTSServices(fileDescriptor: FileDescriptorProt
       methodPrinter.printLn(`export class ${method.getName()} {`);
       methodPrinter.printIndentedLn(`static readonly methodName = "${method.getName()}";`);
       methodPrinter.printIndentedLn(`static readonly service = ${service.getName()};`);
-      methodPrinter.printIndentedLn(`static readonly requestStream = ${method.getClientStreaming()};`);
-      methodPrinter.printIndentedLn(`static readonly responseStream = ${method.getServerStreaming()};`);
+      methodPrinter.printIndentedLn(`static readonly requestStream: ${method.getClientStreaming()} = ${method.getClientStreaming()};`);
+      methodPrinter.printIndentedLn(`static readonly responseStream: ${method.getServerStreaming()} = ${method.getServerStreaming()};`);
       methodPrinter.printIndentedLn(`static readonly requestType = ${requestMessageTypeName};`);
       methodPrinter.printIndentedLn(`static readonly responseType = ${responseMessageTypeName};`);
       methodPrinter.printLn(`}`);


### PR DESCRIPTION
I've been having some problems trying to build an npm package containing all the code generated by the ts-protoc-gen plugin and consuming it from another Typescript project. 

For instance, if I create a new npm project including the service BookService used in the grpc-web repository example, compile it and publish it as a npm package, I get the following error when I try to compile another TS project with a unary grpc invocation to the BookService.GetBook service:

``'Argument of type 'typeof GetBook' is not assignable to parameter of type 'UnaryMethodDefinition<GetBookRequest, {}>'.
  Type 'typeof GetBook' is not assignable to type '{ responseStream: false; }'.
    Types of property 'responseStream' are incompatible.
      Type 'boolean' is not assignable to type 'false'.' ...
``

Looking at the grpc.d.ts declaration file I see that the responseStream property for the UnaryMethodDefinition type is declared as a boolean literal type that only accepts the `false` value:

```
type UnaryMethodDefinition<TRequest extends jspb.Message, TResponse extends jspb.Message> = MethodDefinition<TRequest, TResponse> & {
        responseStream: false;
    };
```

The problem is that the service ts-protoc-gen generates, doesn't set any type for the properties requestStream and responseStream explicitly:

```
export class GetBook {
    static readonly methodName = "GetBook";
    static readonly service = BookService;
    static readonly requestStream = false;
    static readonly responseStream = false;
    static readonly requestType = examplecom_library_book_service_pb.GetBookRequest;
    static readonly responseType = examplecom_library_book_service_pb.Book;
  }
```

If we compile the service with the Typescript compiler setting the declaration flag to true, the type descriptor file it generates for the service looks as follows:

```
class GetBook {
        static readonly methodName: string;
        static readonly service: typeof BookService;
        static readonly requestStream: boolean;
        static readonly responseStream: boolean;
        static readonly requestType: typeof examplecom_library_book_service_pb.GetBookRequest;
        static readonly responseType: typeof examplecom_library_book_service_pb.Book;
    }
```

The properties requestStream and responseStream are declared as boolean but they should have been declared as false instead. This happens because the Typescript compiler doesn't generate the declaration files properly for readonly properties. There is a related issue on Github that hasn’t been resolved yet https://github.com/Microsoft/TypeScript/issues/15881.

With this pull request I suggest adding the boolean literal type explicitly for those properties as a workaround.

