### PR TITLE
Add path to service definition

### DIFF
--- a/src/ts/fileDescriptorTSServices.ts
+++ b/src/ts/fileDescriptorTSServices.ts
@@ -5,9 +5,6 @@ import {FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb
 import {WellKnownTypesMap} from "../WellKnown";
 import {getFieldType, MESSAGE_TYPE} from "./FieldTypes";
 
-const makeSerializer = (messageType: string) => `(obj: ${messageType}) => new Buffer(obj.serializeBinary())`;
-const makeDeserializer = (messageType: string) => `(input: Buffer) => ${messageType}.deserializeBinary(new Uint8Array(input))`;
-
 export function printFileDescriptorTSServices(fileDescriptor: FileDescriptorProto, exportMap: ExportMap) {
   if (fileDescriptor.getServiceList().length === 0) {
     return "";
@@ -55,10 +52,6 @@ export function printFileDescriptorTSServices(fileDescriptor: FileDescriptorProt
       methodPrinter.printIndentedLn(`static readonly requestType = ${requestMessageTypeName};`);
       methodPrinter.printIndentedLn(`static readonly responseType = ${responseMessageTypeName};`);
       methodPrinter.printIndentedLn(`static readonly path = "/${serviceName}/${method.getName()}";`);
-      methodPrinter.printIndentedLn(`static readonly requestSerialize = ${makeSerializer(requestMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static readonly requestDeserialize = ${makeDeserializer(requestMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static readonly responseSerialize = ${makeSerializer(responseMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static readonly responseDeserialize = ${makeDeserializer(responseMessageTypeName)};`);
       methodPrinter.printLn(`}`);
     });
     printer.print(methodPrinter.output);

--- a/src/ts/fileDescriptorTSServices.ts
+++ b/src/ts/fileDescriptorTSServices.ts
@@ -54,11 +54,11 @@ export function printFileDescriptorTSServices(fileDescriptor: FileDescriptorProt
       methodPrinter.printIndentedLn(`static readonly responseStream = ${method.getServerStreaming()};`);
       methodPrinter.printIndentedLn(`static readonly requestType = ${requestMessageTypeName};`);
       methodPrinter.printIndentedLn(`static readonly responseType = ${responseMessageTypeName};`);
-      methodPrinter.printIndentedLn(`static path = "/${serviceName}/${method.getName()}";`);
-      methodPrinter.printIndentedLn(`static requestSerialize = ${makeSerializer(requestMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static requestDeserialize = ${makeDeserializer(requestMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static responseSerialize = ${makeSerializer(responseMessageTypeName)};`);
-      methodPrinter.printIndentedLn(`static responseDeserialize = ${makeDeserializer(responseMessageTypeName)};`);
+      methodPrinter.printIndentedLn(`static readonly path = "/${serviceName}/${method.getName()}";`);
+      methodPrinter.printIndentedLn(`static readonly requestSerialize = ${makeSerializer(requestMessageTypeName)};`);
+      methodPrinter.printIndentedLn(`static readonly requestDeserialize = ${makeDeserializer(requestMessageTypeName)};`);
+      methodPrinter.printIndentedLn(`static readonly responseSerialize = ${makeSerializer(responseMessageTypeName)};`);
+      methodPrinter.printIndentedLn(`static readonly responseDeserialize = ${makeDeserializer(responseMessageTypeName)};`);
       methodPrinter.printLn(`}`);
     });
     printer.print(methodPrinter.output);

--- a/test/ts_test/src/orphan.ts
+++ b/test/ts_test/src/orphan.ts
@@ -12,6 +12,11 @@ describe("ts orphan service", () => {
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.responseStream, false);
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.requestType, orphan_pb.OrphanUnaryRequest);
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.responseType, orphan_pb.OrphanMessage);
+    assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.path, "/OrphanService/DoUnary");
+    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.requestSerialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.requestDeserialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.responseSerialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.responseDeserialize);
 
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.methodName, "DoStream");
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.service, orphan_pb_service.OrphanService);
@@ -19,5 +24,10 @@ describe("ts orphan service", () => {
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.responseStream, true);
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.requestType, orphan_pb.OrphanStreamRequest);
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.responseType, orphan_pb.OrphanMessage);
+    assert.strictEqual(orphan_pb_service.OrphanService.DoStream.path, "/OrphanService/DoStream");
+    assert.isDefined(orphan_pb_service.OrphanService.DoStream.requestSerialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoStream.requestDeserialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoStream.responseSerialize);
+    assert.isDefined(orphan_pb_service.OrphanService.DoStream.responseDeserialize);
   });
 });

--- a/test/ts_test/src/orphan.ts
+++ b/test/ts_test/src/orphan.ts
@@ -13,10 +13,6 @@ describe("ts orphan service", () => {
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.requestType, orphan_pb.OrphanUnaryRequest);
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.responseType, orphan_pb.OrphanMessage);
     assert.strictEqual(orphan_pb_service.OrphanService.DoUnary.path, "/OrphanService/DoUnary");
-    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.requestSerialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.requestDeserialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.responseSerialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoUnary.responseDeserialize);
 
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.methodName, "DoStream");
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.service, orphan_pb_service.OrphanService);
@@ -25,9 +21,5 @@ describe("ts orphan service", () => {
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.requestType, orphan_pb.OrphanStreamRequest);
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.responseType, orphan_pb.OrphanMessage);
     assert.strictEqual(orphan_pb_service.OrphanService.DoStream.path, "/OrphanService/DoStream");
-    assert.isDefined(orphan_pb_service.OrphanService.DoStream.requestSerialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoStream.requestDeserialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoStream.responseSerialize);
-    assert.isDefined(orphan_pb_service.OrphanService.DoStream.responseDeserialize);
   });
 });

--- a/test/ts_test/src/service.ts
+++ b/test/ts_test/src/service.ts
@@ -14,10 +14,6 @@ describe("ts service", () => {
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.requestType, simple_service_pb.UnaryRequest);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.responseType, external_child_message_pb.ExternalChildMessage);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.path, "/examplecom.SimpleService/DoUnary");
-    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.requestSerialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.requestDeserialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.responseSerialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.responseDeserialize);
 
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.methodName, "DoStream");
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.service, simple_service_pb_service.SimpleService);
@@ -26,9 +22,5 @@ describe("ts service", () => {
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.requestType, simple_service_pb.StreamRequest);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.responseType, external_child_message_pb.ExternalChildMessage);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.path, "/examplecom.SimpleService/DoStream");
-    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.requestSerialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.requestDeserialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.responseSerialize);
-    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.responseDeserialize);
   });
 });

--- a/test/ts_test/src/service.ts
+++ b/test/ts_test/src/service.ts
@@ -13,6 +13,11 @@ describe("ts service", () => {
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.responseStream, false);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.requestType, simple_service_pb.UnaryRequest);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.responseType, external_child_message_pb.ExternalChildMessage);
+    assert.strictEqual(simple_service_pb_service.SimpleService.DoUnary.path, "/examplecom.SimpleService/DoUnary");
+    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.requestSerialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.requestDeserialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.responseSerialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoUnary.responseDeserialize);
 
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.methodName, "DoStream");
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.service, simple_service_pb_service.SimpleService);
@@ -20,5 +25,10 @@ describe("ts service", () => {
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.responseStream, true);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.requestType, simple_service_pb.StreamRequest);
     assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.responseType, external_child_message_pb.ExternalChildMessage);
+    assert.strictEqual(simple_service_pb_service.SimpleService.DoStream.path, "/examplecom.SimpleService/DoStream");
+    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.requestSerialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.requestDeserialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.responseSerialize);
+    assert.isDefined(simple_service_pb_service.SimpleService.DoStream.responseDeserialize);
   });
 });


### PR DESCRIPTION
Adds path to generated service definition.

This enables the generated service definition (NAME_pb_service.ts) to be used directly with grpc.Server::addService(), after extending the generated class with the appropriate serialiser and deserialiser.

Most importantly, it ensures the knowledge of the path is embedded within the service definition for use by client and server without having to specify it in two places.