### PR TITLE
Added ability to generate typings for grpc-node service files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "google-protobuf": "^3.2.0"
   },
   "devDependencies": {
+    "@types/protobufjs": "^6.0.0",
     "@types/chai": "^3.4.35",
     "@types/google-protobuf": "^3.2.4",
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.5",
     "babel": "^6.5.2",
     "chai": "^3.5.0",
+    "grpc": "^1.9.1",
     "mocha": "^3.2.0",
     "source-map-support": "^0.4.14",
     "tslint": "^4.5.1",

--- a/src/ts/fileDescriptorTSServices.ts
+++ b/src/ts/fileDescriptorTSServices.ts
@@ -76,3 +76,126 @@ export function printFileDescriptorTSServices(fileDescriptor: FileDescriptorProt
 
   return printer.getOutput();
 }
+
+export function printFileDescriptorTSGRPC(fileDescriptor: FileDescriptorProto, exportMap: ExportMap) {
+  if (fileDescriptor.getServiceList().length === 0) {
+    return "";
+  }
+
+  const fileName = fileDescriptor.getName();
+  const packageName = fileDescriptor.getPackage();
+  const upToRoot = getPathToRoot(fileName);
+
+  const printer = new Printer(0);
+  printer.printLn(`// package: ${packageName}`);
+  printer.printLn(`// file: ${fileDescriptor.getName()}`);
+  printer.printEmptyLn();
+
+  // Need to import the non-service file that was generated for this .proto file
+  const asPseudoNamespace = filePathToPseudoNamespace(fileName);
+  printer.printLn(`import * as GRPC from 'grpc';`);
+  printer.printLn(`import * as ${asPseudoNamespace} from "${upToRoot}${filePathFromProtoWithoutExtension(fileName)}";`);
+
+  fileDescriptor.getDependencyList()
+    .filter((dependency: string) => {
+      return isUsed(fileDescriptor, filePathToPseudoNamespace(dependency), exportMap);
+    })
+    .forEach((dependency: string) => {
+      const pseudoNamespace = filePathToPseudoNamespace(dependency);
+      if (dependency in WellKnownTypesMap) {
+        printer.printLn(`import * as ${pseudoNamespace} from "${WellKnownTypesMap[dependency]}";`);
+      } else {
+        const filePath = filePathFromProtoWithoutExtension(dependency);
+        printer.printLn(`import * as ${pseudoNamespace} from "${upToRoot + filePath}";`);
+      }
+    });
+
+  fileDescriptor.getServiceList().forEach(service => {
+    printer.printLn("");
+    printer.printLn(`export = ${service.getName()};`);
+    printer.printLn(`declare namespace ${service.getName()} {`);
+
+    const methodImplTypesPrinter = new Printer(1);
+    methodImplTypesPrinter.printLn(`namespace MethodImplTypes {`);
+
+    const methodImplsPrinter = new Printer(1);
+    methodImplsPrinter.printLn(`interface MethodImpls {`);
+
+    const clientClassName = `${service.getName()}ClientClass`;
+    const clientClassPrinter = new Printer(1);
+    clientClassPrinter.printLn(`class ${clientClassName} extends GRPC.Client {`);
+
+    const serviceInterfaceName = `I${service.getName()}Service`;
+    const servicePrinter = new Printer(1);
+    servicePrinter.printLn(
+        `interface ${serviceInterfaceName} extends GRPC.ServiceDefinition<MethodImpls> {`);
+
+    service.getMethodList().forEach(method => {
+      const isClientStreaming = method.getClientStreaming();
+      const isServerStreaming = method.getServerStreaming();
+
+      const requestMessageTypeName = getFieldType(MESSAGE_TYPE, method.getInputType().slice(1), "", exportMap);
+      const responseMessageTypeName = getFieldType(MESSAGE_TYPE, method.getOutputType().slice(1), "", exportMap);
+
+      const grpcMethodName = lowerFirstLetter(method.getName());
+      if (!isClientStreaming && !isServerStreaming) {
+        // Unary
+        methodImplTypesPrinter.printIndentedLn(`type ${grpcMethodName} = GRPC.handleUnaryCall<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+        methodImplsPrinter.printIndentedLn(`${grpcMethodName}: MethodImplTypes.${grpcMethodName};`);
+        clientClassPrinter.printIndentedLn(
+            `${grpcMethodName}(` +
+                `request: ${requestMessageTypeName}, ` +
+                `callback: GRPC.requestCallback<${responseMessageTypeName}>` +
+              `): GRPC.ClientUnaryCall;`);
+      } else if (!isClientStreaming && isServerStreaming) {
+        // Server streaming
+        methodImplTypesPrinter.printIndentedLn(`type ${grpcMethodName} = GRPC.handleServerStreamingCall<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+        methodImplsPrinter.printIndentedLn(`${grpcMethodName}: MethodImplTypes.${grpcMethodName};`);
+        clientClassPrinter.printIndentedLn(
+            `${grpcMethodName}(` +
+              `request: ${requestMessageTypeName}` +
+            `): GRPC.ClientReadableStream<${responseMessageTypeName}>;`);
+      } else if (isClientStreaming && !isServerStreaming) {
+        // Client streaming
+        methodImplTypesPrinter.printIndentedLn(`type ${grpcMethodName} = GRPC.handleClientStreamingCall<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+        methodImplsPrinter.printIndentedLn(`${grpcMethodName}: MethodImplTypes.${grpcMethodName};`);
+        clientClassPrinter.printIndentedLn(
+            `${grpcMethodName}(` +
+              `callback: GRPC.requestCallback<${responseMessageTypeName}>` +
+            `): GRPC.ClientWritableStream<${requestMessageTypeName}>;`);
+      } else {
+        // Duplex
+        methodImplTypesPrinter.printIndentedLn(`type ${grpcMethodName} = GRPC.handleBidiStreamingCall<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+        methodImplsPrinter.printIndentedLn(`${grpcMethodName}: MethodImplTypes.${grpcMethodName};`);
+        clientClassPrinter.printIndentedLn(
+            `${grpcMethodName}(): GRPC.ClientDuplexStream<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+      }
+
+      servicePrinter.printIndentedLn(
+        `${grpcMethodName}: GRPC.MethodDefinition<${requestMessageTypeName}, ${responseMessageTypeName}>;`);
+    });
+
+    methodImplTypesPrinter.printLn(`}`);
+    methodImplsPrinter.printLn(`}`);
+    clientClassPrinter.printLn(`}`);
+    servicePrinter.printLn(`}`);
+
+    printer.print(methodImplTypesPrinter.output);
+    printer.print(methodImplsPrinter.output);
+
+    printer.printLn("");
+    printer.print(clientClassPrinter.output);
+    printer.print(servicePrinter.output);
+
+    printer.printLn("");
+    printer.printIndentedLn(`const ${service.getName()}Service: ${serviceInterfaceName};`);
+    printer.printIndentedLn(`const ${service.getName()}Client: ${clientClassName};`);
+    printer.printLn(`}`);
+  });
+
+  return printer.getOutput();
+}
+
+function lowerFirstLetter(str: string) {
+  return str.charAt(0).toLowerCase() + str.slice(1);
+}

--- a/test/ts_test/generate.sh
+++ b/test/ts_test/generate.sh
@@ -9,7 +9,7 @@ mkdir generated
 protoc \
   --plugin=protoc-gen-ts=../../bin/protoc-gen-ts \
   --js_out=import_style=commonjs,binary:generated \
-  --ts_out=service=true:generated \
+  --ts_out=service=true,grpc=true:generated \
   -I ../proto \
   ../proto/othercom/*.proto \
   ../proto/examplecom/*.proto \


### PR DESCRIPTION
This PR adds the ability for users to output typings for the service files generated by protoc for node. Let me know if you have any questions or concerns about adding this to the library :)

Note: The addition of the two deps is strictly for the types they provide.