### PR TITLE
Tidy up Bazel build

### DIFF
--- a/bin/BUILD
+++ b/bin/BUILD
@@ -10,13 +10,3 @@ nodejs_binary(
     entry_point = "ts_protoc_gen/src/ts_index",
     args = ["--node_options=--expose-gc"],
 )
-
-nodejs_binary(
-    name = "protoc-gen-js_service",
-    data = [
-        "@//:node_modules",
-        "@//src",
-    ],
-    entry_point = "ts_protoc_gen/src/js_service_index",
-    args = ["--node_options=--expose-gc"],
-)

--- a/src/BUILD
+++ b/src/BUILD
@@ -5,7 +5,6 @@ ts_library(
     name = "src",
     srcs = glob([
         "*.ts",
-        "js/*.ts",
         "ts/*.ts",
     ]),
     deps = [],


### PR DESCRIPTION
- Remove reference to `protoc-gen-js_service` binary which was removed in #44
- Remove `js/*.ts` source path which was removed in #44