### PR TITLE
Remove invalid npm script commands

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,5 @@
 {
   "scripts": {
-    "lint": "tslint ts_test/src/**/*.ts",
-    "lint:fix": "npm run lint -- --fix",
     "build": "cd ts_test && npm run build",
     "test": "npm run lint && npm run build && (cd ts_test && npm run test)"
   }

--- a/test/package.json
+++ b/test/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
     "build": "cd ts_test && npm run build",
-    "test": "npm run lint && npm run build && (cd ts_test && npm run test)"
+    "test": "npm run build && (cd ts_test && npm run test)"
   }
 }


### PR DESCRIPTION
Removes `npm lint` commands from inside the `test` directory. These scripts cannot be run as they have a dependency on `tslint` which is a dependency of the parent and therefore unavailable unless installed in global scope.