### PR TITLE
Add compatibility with rules_typescript

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -50,7 +50,7 @@ def _typescript_proto_library_impl(ctx):
     proto_inputs.append(normalized_file)
     append_to_outputs(ctx, file_name, js_outputs, dts_outputs, file_modifications)
   
-  outputs = dts + js
+  outputs = dts_outputs + js_outputs
 
   if not file_modifications:
     file_modifications.append("echo \"No services generated\"")


### PR DESCRIPTION
This was taken from: https://github.com/bazelbuild/rules_typescript/blob/d25f3ce7438d8fb3497115f04a029232c8ef2861/internal/protobufjs/ts_proto_library.bzl#L93 and adapted for this rule

Edit: Just to clarify this was necessary for me to get grpc-web work with rules_typescript.