### PR TITLE
Add hint for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ msg.setName("John Doe");
 To generate client-side service stubs from your protobuf files you must configure ts-protoc-gen to emit service definitions by passing the `service=true` param to the `--ts_out` flag, eg:
 
 ```
-# Path to this plugin
+# Path to this plugin, Note this must be an abolsute path on Windows (see #15)
 PROTOC_GEN_TS_PATH="./node_modules/.bin/protoc-gen-ts"
 
 # Directory to write generated code to (.js and .d.ts files) 


### PR DESCRIPTION
Hint that the path to ts-protoc-gen must be absolute on Windows. Fixes #100