### PR TITLE
Make ServiceError optionally null

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -93,11 +93,11 @@ export class SimpleServiceClient {
   doUnary(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: proto_othercom_external_child_message_pb.ExternalChildMessage|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_othercom_external_child_message_pb.ExternalChildMessage|null) => void
   ): void;
   doUnary(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
-    callback: (error: ServiceError, responseMessage: proto_othercom_external_child_message_pb.ExternalChildMessage|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_othercom_external_child_message_pb.ExternalChildMessage|null) => void
   ): void;
   doServerStream(requestMessage: proto_examplecom_simple_service_pb.StreamRequest, metadata?: grpc.Metadata): ResponseStream<proto_othercom_external_child_message_pb.ExternalChildMessage>;
   doClientStream(metadata?: grpc.Metadata): RequestStream<google_protobuf_empty_pb.Empty>;
@@ -105,11 +105,11 @@ export class SimpleServiceClient {
   delete(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: proto_examplecom_simple_service_pb.UnaryResponse|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_examplecom_simple_service_pb.UnaryResponse|null) => void
   ): void;
   delete(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
-    callback: (error: ServiceError, responseMessage: proto_examplecom_simple_service_pb.UnaryResponse|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_examplecom_simple_service_pb.UnaryResponse|null) => void
   ): void;
 }
 

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -61,11 +61,11 @@ export class OrphanServiceClient {
   doUnary(
     requestMessage: proto_orphan_pb.OrphanUnaryRequest,
     metadata: grpc.Metadata,
-    callback: (error: ServiceError, responseMessage: proto_orphan_pb.OrphanMessage|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_orphan_pb.OrphanMessage|null) => void
   ): void;
   doUnary(
     requestMessage: proto_orphan_pb.OrphanUnaryRequest,
-    callback: (error: ServiceError, responseMessage: proto_orphan_pb.OrphanMessage|null) => void
+    callback: (error: ServiceError|null, responseMessage: proto_orphan_pb.OrphanMessage|null) => void
   ): void;
   doStream(requestMessage: proto_orphan_pb.OrphanStreamRequest, metadata?: grpc.Metadata): ResponseStream<proto_orphan_pb.OrphanMessage>;
 }

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -509,11 +509,11 @@ function printUnaryStubMethodTypes(printer: CodePrinter, method: RPCMethodDescri
              .printLn(`${method.nameAsCamelCase}(`)
       .indent().printLn(`requestMessage: ${method.requestType},`)
                .printLn(`metadata: grpc.Metadata,`)
-               .printLn(`callback: (error: ServiceError, responseMessage: ${method.responseType}|null) => void`)
+               .printLn(`callback: (error: ServiceError|null, responseMessage: ${method.responseType}|null) => void`)
     .dedent().printLn(`): void;`)
              .printLn(`${method.nameAsCamelCase}(`)
       .indent().printLn(`requestMessage: ${method.requestType},`)
-               .printLn(`callback: (error: ServiceError, responseMessage: ${method.responseType}|null) => void`)
+               .printLn(`callback: (error: ServiceError|null, responseMessage: ${method.responseType}|null) => void`)
     .dedent().printLn(`): void;`);
 }
 

--- a/test/integration/service/grpcweb.ts
+++ b/test/integration/service/grpcweb.ts
@@ -166,9 +166,9 @@ describe("service/grpc-web", () => {
               assert.ok(error !== null && typeof error === "object", "should yield an error");
               assert.ok(response === null, "should yield null instead of a response");
 
-              assert.equal(error.message, "some internal error", "should expose the grpc error message (.message)");
-              assert.equal(error.code, 13, "should expose the grpc status code (.code)");
-              assert.ok(error.metadata instanceof grpc.Metadata, "should expose the trailing response metadata (.metadata)");
+              assert.equal(error!.message, "some internal error", "should expose the grpc error message (.message)");
+              assert.equal(error!.code, 13, "should expose the grpc status code (.code)");
+              assert.ok(error!.metadata instanceof grpc.Metadata, "should expose the trailing response metadata (.metadata)");
               done();
             });
       });


### PR DESCRIPTION
[`ServiceError`'s can be `null`](https://github.com/improbable-eng/ts-protoc-gen/blob/master/src/service/grpcweb.ts#L342), but the TypeScript type doesn't reflect that. This just updates the type declaration for `ServiceError`.