### PR TITLE
Transport member of ServiceClientOptions should be optional

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -62,7 +62,7 @@ export class SimpleService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport: grpc.TransportConstructor; debug?: boolean }
+export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }
 
 interface ResponseStream<T> {
   cancel(): void;

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -30,7 +30,7 @@ export class OrphanService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport: grpc.TransportConstructor; debug?: boolean }
+export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }
 
 interface ResponseStream<T> {
   cancel(): void;

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -204,7 +204,7 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
 
   printer.printLn(`export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }`);
   printer.printLn(`export type Status = { details: string, code: number; metadata: grpc.Metadata }`);
-  printer.printLn(`export type ServiceClientOptions = { transport: grpc.TransportConstructor; debug?: boolean }`);
+  printer.printLn(`export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }`);
   printer.printEmptyLn();
   printer.printLn(`interface ResponseStream<T> {`);
   printer.printIndentedLn(`cancel(): void;`);


### PR DESCRIPTION
What the title says. Should be good, given that clients are initialized with...

```
function BookServiceClient(serviceHost, options) {
  this.serviceHost = serviceHost;
  this.options = options || {};
}
```