### PR TITLE
CI should check that generated code has been committed

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -33,7 +33,7 @@ else
 fi
 
 wget ${PROTOC_URL} --output-document="protoc-${PROTOC_VERSION}.zip"
-tar -C protoc -xzf "protoc-${PROTOC_VERSION}.zip"
+unzip "protoc-${PROTOC_VERSION}.zip" -d protoc
 rm "protoc-${PROTOC_VERSION}.zip"
 
 PROTOC=./protoc/bin/protoc

--- a/generate.sh
+++ b/generate.sh
@@ -24,13 +24,17 @@ PROTOC_VERSION="3.5.1"
 echo "Downloading protoc v${PROTOC_VERSION} for ${platform}..."
 mkdir -p protoc
 if [[ $platform == 'Linux' ]]; then
-    curl -L https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip | tar xz -C protoc
+    PROTOC_URL="https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
 elif [[ $platform == 'Mac' ]]; then
-    curl -L https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip | tar xz -C protoc
+    PROTOC_URL="https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-x86_64.zip"
 else
     echo "Cannot download protoc. ${platform} is not currently supported by ts-protoc-gen"
     exit 1
 fi
+
+wget ${PROTOC_URL} --output-document="protoc-${PROTOC_VERSION}.zip"
+tar -C protoc -xzf "protoc-${PROTOC_VERSION}.zip"
+rm "protoc-${PROTOC_VERSION}.zip"
 
 PROTOC=./protoc/bin/protoc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-protoc-gen",
-  "version": "0.7.7",
+  "version": "0.7.8-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/travis-ci-build.sh
+++ b/travis-ci-build.sh
@@ -3,4 +3,12 @@ set -ex
 
 npm run lint
 npm test
+
+./generate.sh
+MODIFIED_FILES=$(git diff --name-only)
+if [[ -n $MODIFIED_FILES ]]; then
+  echo "ERROR: Changes detected in generated code, please run './generate.sh' and check-in the changes."
+  exit 1
+fi
+
 bazel build //...:all


### PR DESCRIPTION
Add a travis build step which re-generates the generated code and then checks for changes to the workspce. If any are detected it will fail the build and prompt the user to run the `./generate.sh` script.