### PR TITLE
Correct generated client, bidi stream method stubs

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -80,13 +80,13 @@ interface RequestStream<T> {
   on(type: 'end', handler: () => void): RequestStream<T>;
   on(type: 'status', handler: (status: Status) => void): RequestStream<T>;
 }
-interface BidirectionalStream<T> {
-  write(message: T): BidirectionalStream<T>;
+interface BidirectionalStream<ReqT, ResT> {
+  write(message: ReqT): BidirectionalStream<ReqT, ResT>;
   end(): void;
   cancel(): void;
-  on(type: 'data', handler: (message: T) => void): BidirectionalStream<T>;
-  on(type: 'end', handler: () => void): BidirectionalStream<T>;
-  on(type: 'status', handler: (status: Status) => void): BidirectionalStream<T>;
+  on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;
 }
 
 export class SimpleServiceClient {
@@ -103,8 +103,8 @@ export class SimpleServiceClient {
     callback: (error: ServiceError|null, responseMessage: proto_othercom_external_child_message_pb.ExternalChildMessage|null) => void
   ): UnaryResponse;
   doServerStream(requestMessage: proto_examplecom_simple_service_pb.StreamRequest, metadata?: grpc.Metadata): ResponseStream<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  doClientStream(metadata?: grpc.Metadata): RequestStream<google_protobuf_empty_pb.Empty>;
-  doBidiStream(metadata?: grpc.Metadata): BidirectionalStream<proto_othercom_external_child_message_pb.ExternalChildMessage>;
+  doClientStream(metadata?: grpc.Metadata): RequestStream<proto_examplecom_simple_service_pb.StreamRequest>;
+  doBidiStream(metadata?: grpc.Metadata): BidirectionalStream<proto_examplecom_simple_service_pb.StreamRequest, proto_othercom_external_child_message_pb.ExternalChildMessage>;
   delete(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
     metadata: grpc.Metadata,

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -48,13 +48,13 @@ interface RequestStream<T> {
   on(type: 'end', handler: () => void): RequestStream<T>;
   on(type: 'status', handler: (status: Status) => void): RequestStream<T>;
 }
-interface BidirectionalStream<T> {
-  write(message: T): BidirectionalStream<T>;
+interface BidirectionalStream<ReqT, ResT> {
+  write(message: ReqT): BidirectionalStream<ReqT, ResT>;
   end(): void;
   cancel(): void;
-  on(type: 'data', handler: (message: T) => void): BidirectionalStream<T>;
-  on(type: 'end', handler: () => void): BidirectionalStream<T>;
-  on(type: 'status', handler: (status: Status) => void): BidirectionalStream<T>;
+  on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;
 }
 
 export class OrphanServiceClient {

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -222,13 +222,13 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
   printer.printIndentedLn(`on(type: 'end', handler: () => void): RequestStream<T>;`);
   printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): RequestStream<T>;`);
   printer.printLn(`}`);
-  printer.printLn(`interface BidirectionalStream<T> {`);
-  printer.printIndentedLn(`write(message: T): BidirectionalStream<T>;`);
+  printer.printLn(`interface BidirectionalStream<ReqT, ResT> {`);
+  printer.printIndentedLn(`write(message: ReqT): BidirectionalStream<ReqT, ResT>;`);
   printer.printIndentedLn(`end(): void;`);
   printer.printIndentedLn(`cancel(): void;`);
-  printer.printIndentedLn(`on(type: 'data', handler: (message: T) => void): BidirectionalStream<T>;`);
-  printer.printIndentedLn(`on(type: 'end', handler: () => void): BidirectionalStream<T>;`);
-  printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): BidirectionalStream<T>;`);
+  printer.printIndentedLn(`on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;`);
+  printer.printIndentedLn(`on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;`);
+  printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;`);
   printer.printLn(`}`);
   printer.printEmptyLn();
 
@@ -531,9 +531,9 @@ function printServerStreamStubMethodTypes(printer: CodePrinter, method: RPCMetho
 }
 
 function printClientStreamStubMethodTypes(printer: CodePrinter, method: RPCMethodDescriptor) {
-  printer.printLn(`${method.nameAsCamelCase}(metadata?: grpc.Metadata): RequestStream<${method.responseType}>;`);
+  printer.printLn(`${method.nameAsCamelCase}(metadata?: grpc.Metadata): RequestStream<${method.requestType}>;`);
 }
 
 function printBidirectionalStubMethodTypes(printer: CodePrinter, method: RPCMethodDescriptor) {
-  printer.printLn(`${method.nameAsCamelCase}(metadata?: grpc.Metadata): BidirectionalStream<${method.responseType}>;`);
+  printer.printLn(`${method.nameAsCamelCase}(metadata?: grpc.Metadata): BidirectionalStream<${method.requestType}, ${method.responseType}>;`);
 }

--- a/test/integration/service/grpcweb.ts
+++ b/test/integration/service/grpcweb.ts
@@ -335,7 +335,8 @@ describe("service/grpc-web", () => {
     });
 
     describe("client streaming", () => {
-      const [ payload ] = makePayloads("some value");
+      const payload = new StreamRequest();
+      payload.setSomeString("some value");
 
       it("should route the request to the expected endpoint", (done) => {
         let targetUrl = "";
@@ -389,7 +390,10 @@ describe("service/grpc-web", () => {
       });
 
       it("should allow the caller to supply multiple messages", (done) => {
-        const [ reqMsgOne, reqMsgTwo ] = makePayloads("one", "two");
+        const reqMsgOne = new StreamRequest();
+        reqMsgOne.setSomeString("one");
+        const reqMsgTwo = new StreamRequest();
+        reqMsgTwo.setSomeString("two");
         const sentMessageBytes: ArrayBufferView[] = [];
 
         makeClient(new StubTransportBuilder().withMessageListener(v => { sentMessageBytes.push(v); }))
@@ -449,7 +453,8 @@ describe("service/grpc-web", () => {
     });
 
     describe("bidirectional streaming", () => {
-      const [ payload ] = makePayloads("some value");
+      const payload = new StreamRequest();
+      payload.setSomeString("some value");
 
       it("should route the request to the expected endpoint", (done) => {
         let targetUrl = "";
@@ -503,7 +508,7 @@ describe("service/grpc-web", () => {
 
       it("should handle an error returned ahead of any data by the server", (done) => {
         makeClient(new StubTransportBuilder().withPreMessagesError(grpc.Code.Internal, "some error"))
-          .doClientStream()
+          .doBidiStream()
           .on("status", (status) => {
             assert.equal(status.code, grpc.Code.Internal, "expected grpc status code returned");
             assert.equal(status.details, "some error", "expected grpc error details returned");
@@ -531,7 +536,10 @@ describe("service/grpc-web", () => {
       });
 
       it("should allow the caller to supply multiple messages", (done) => {
-        const [ reqMsgOne, reqMsgTwo ] = makePayloads("one", "two");
+        const reqMsgOne = new StreamRequest();
+        reqMsgOne.setSomeString("one");
+        const reqMsgTwo = new StreamRequest();
+        reqMsgTwo.setSomeString("two");
         const sentMessageBytes: ArrayBufferView[] = [];
 
         makeClient(new StubTransportBuilder().withMessageListener(v => { sentMessageBytes.push(v); }))


### PR DESCRIPTION
It appears we were using the responseType instead of the requestType when creating the stream.

Fixes #132, #133