### PR TITLE
Upgrade grpc-web-client to 0.7.0

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -62,7 +62,6 @@ export class SimpleService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }
 
 interface UnaryResponse {
   cancel(): void;
@@ -92,7 +91,7 @@ interface BidirectionalStream<ReqT, ResT> {
 export class SimpleServiceClient {
   readonly serviceHost: string;
 
-  constructor(serviceHost: string, options?: ServiceClientOptions);
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
   doUnary(
     requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
     metadata: grpc.Metadata,

--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -62,7 +62,7 @@ export class SimpleService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }
+export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }
 
 interface UnaryResponse {
   cancel(): void;

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -30,7 +30,7 @@ export class OrphanService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }
+export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }
 
 interface UnaryResponse {
   cancel(): void;

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -30,7 +30,6 @@ export class OrphanService {
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
 export type Status = { details: string, code: number; metadata: grpc.Metadata }
-export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }
 
 interface UnaryResponse {
   cancel(): void;
@@ -60,7 +59,7 @@ interface BidirectionalStream<ReqT, ResT> {
 export class OrphanServiceClient {
   readonly serviceHost: string;
 
-  constructor(serviceHost: string, options?: ServiceClientOptions);
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
   doUnary(
     requestMessage: proto_orphan_pb.OrphanUnaryRequest,
     metadata: grpc.Metadata,

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,9 +302,9 @@
       "dev": true
     },
     "grpc-web-client": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/grpc-web-client/-/grpc-web-client-0.6.2.tgz",
-      "integrity": "sha512-7LSp9Gr0cWLJp53ijrNW+KHNyw8rZKDMMmFKmRkxu1QJLU9vuE+5hG4NTc8ao5YwuP1rsBQi74eZ1R+sOiQVtg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/grpc-web-client/-/grpc-web-client-0.7.0.tgz",
+      "integrity": "sha512-tydslNg6pPHi61aMs0HoaETTtyDR5TQyDZ0AQhbbURpOK2NW8IMrUGs/i1UMkS0H64Vj7PuggSAhDohP41yubQ==",
       "dev": true,
       "requires": {
         "browser-headers": "0.4.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^7.0.52",
     "babel": "^6.5.2",
     "chai": "^3.5.0",
-    "grpc-web-client": "^0.6.0",
+    "grpc-web-client": "^0.7.0",
     "lodash": "^4.17.5",
     "lodash.isequal": "^4.5.0",
     "mocha": "^5.2.0",

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -204,7 +204,6 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
 
   printer.printLn(`export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }`);
   printer.printLn(`export type Status = { details: string, code: number; metadata: grpc.Metadata }`);
-  printer.printLn(`export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }`);
   printer.printEmptyLn();
   printer.printLn("interface UnaryResponse {");
   printer.printIndentedLn("cancel(): void;");
@@ -497,7 +496,7 @@ function printServiceStubTypes(methodPrinter: Printer, service: RPCDescriptor) {
            .printLn(`export class ${service.name}Client {`)
     .indent().printLn(`readonly serviceHost: string;`)
         .printEmptyLn()
-             .printLn(`constructor(serviceHost: string, options?: ServiceClientOptions);`);
+             .printLn(`constructor(serviceHost: string, options?: grpc.RpcOptions);`);
 
   service.methods.forEach((method: RPCMethodDescriptor) => {
     if (method.requestStream && method.responseStream) {

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -204,7 +204,7 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
 
   printer.printLn(`export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }`);
   printer.printLn(`export type Status = { details: string, code: number; metadata: grpc.Metadata }`);
-  printer.printLn(`export type ServiceClientOptions = { transport?: grpc.TransportConstructor; debug?: boolean }`);
+  printer.printLn(`export type ServiceClientOptions = { transport?: grpc.Transport; debug?: boolean }`);
   printer.printEmptyLn();
   printer.printLn("interface UnaryResponse {");
   printer.printIndentedLn("cancel(): void;");

--- a/test/helpers/fakeGrpcTransport.ts
+++ b/test/helpers/fakeGrpcTransport.ts
@@ -1,6 +1,5 @@
 import { Message } from "google-protobuf";
 import { grpc } from "grpc-web-client";
-import { Transport, TransportConstructor, TransportOptions } from "grpc-web-client/dist/transports/Transport";
 import * as _ from "lodash";
 
 function frameResponse(request: Message): Uint8Array {
@@ -34,7 +33,7 @@ function frameTrailers(trailers: grpc.Metadata): Uint8Array {
 }
 
 export class StubTransportBuilder {
-  private requestListener: (options: TransportOptions) => void;
+  private requestListener: (options: grpc.TransportOptions) => void;
   private headersListener: (headers: grpc.Metadata) => void;
   private messageListener: (messageBytes: ArrayBufferView) => void;
   private finishSendListener: () => void;
@@ -47,7 +46,7 @@ export class StubTransportBuilder {
   private trailers: grpc.Metadata | null = null;
   private autoTrigger: boolean = true;
 
-  withRequestListener(requestListener: (options: TransportOptions) => void) {
+  withRequestListener(requestListener: (options: grpc.TransportOptions) => void) {
     this.requestListener = requestListener;
     return this;
   }
@@ -111,7 +110,7 @@ export class StubTransportBuilder {
     const mock = this;
 
     const triggers = {
-      options: null as (TransportOptions | null),
+      options: null as (grpc.TransportOptions | null),
       sendHeaders: () => {
         if (!triggers.options) {
           throw new Error("sendHeaders called before transport had been invoked");
@@ -170,7 +169,7 @@ export class StubTransportBuilder {
       },
     };
 
-    const transportConstructor: TransportConstructor = (optionsArg: TransportOptions) => {
+    const transportConstructor = (optionsArg: grpc.TransportOptions) => {
       triggers.options = optionsArg;
 
       if (mock.requestListener) {
@@ -208,8 +207,7 @@ export class StubTransportBuilder {
   }
 }
 
-export interface TriggerableTransport {
-  (options: TransportOptions): Transport;
+export interface TriggerableTransport extends grpc.TransportFactory {
   sendHeaders(): boolean;
   sendMessages(): boolean;
   sendTrailers(): boolean;

--- a/test/integration/service/grpcweb.ts
+++ b/test/integration/service/grpcweb.ts
@@ -10,7 +10,6 @@ import { SimpleService, SimpleServiceClient } from "../../../examples/generated/
 import { StreamRequest, UnaryRequest } from "../../../examples/generated/proto/examplecom/simple_service_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
-
 describe("service/grpc-web", () => {
   describe("generated service definitions", () => {
 


### PR DESCRIPTION
- change signature on Service Stubs to expect `grpc.Transport` interface
- Patch up `fakeGrpcTransport` to use the publically exported interfaces