### PR TITLE
generate clients that use promises for unary methods

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -115,3 +115,15 @@ export class SimpleServiceClient {
   ): UnaryResponse;
 }
 
+export class SimpleServicePromisesClient {
+  readonly serviceHost: string;
+
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
+  doUnary(
+    requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
+  ): Promise<proto_othercom_external_child_message_pb.ExternalChildMessage>;
+  delete(
+    requestMessage: proto_examplecom_simple_service_pb.UnaryRequest,
+  ): Promise<proto_examplecom_simple_service_pb.UnaryResponse>;
+}
+

--- a/examples/generated/proto/examplecom/simple_service_pb_service.js
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.js
@@ -252,4 +252,38 @@ SimpleServiceClient.prototype.delete = function pb_delete(requestMessage, metada
 };
 
 exports.SimpleServiceClient = SimpleServiceClient;
+function SimpleServicePromisesClient(serviceHost, options) {
+  this.client = new SimpleServiceClient(serviceHost, options);
+}
+
+SimpleServicePromisesClient.prototype.doUnary = function doUnary(requestMessage) {
+  var client = this.client;
+  return new Promise(function (resolve, reject) {
+    client.doUnary(requestMessage, function(error, responseMessage) {
+      if (error !== null) {
+        reject(error);
+      } else {
+        resolve(responseMessage);
+      }
+    });
+  });
+};
+
+
+
+
+SimpleServicePromisesClient.prototype.delete = function pb_delete(requestMessage) {
+  var client = this.client;
+  return new Promise(function (resolve, reject) {
+    client.pb_delete(requestMessage, function(error, responseMessage) {
+      if (error !== null) {
+        reject(error);
+      } else {
+        resolve(responseMessage);
+      }
+    });
+  });
+};
+
+exports.SimpleServicePromisesClient = SimpleServicePromisesClient;
 

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -72,3 +72,12 @@ export class OrphanServiceClient {
   doStream(requestMessage: proto_orphan_pb.OrphanStreamRequest, metadata?: grpc.Metadata): ResponseStream<proto_orphan_pb.OrphanMessage>;
 }
 
+export class OrphanServicePromisesClient {
+  readonly serviceHost: string;
+
+  constructor(serviceHost: string, options?: grpc.RpcOptions);
+  doUnary(
+    requestMessage: proto_orphan_pb.OrphanUnaryRequest,
+  ): Promise<proto_orphan_pb.OrphanMessage>;
+}
+

--- a/examples/generated/proto/orphan_pb_service.js
+++ b/examples/generated/proto/orphan_pb_service.js
@@ -106,4 +106,23 @@ OrphanServiceClient.prototype.doStream = function doStream(requestMessage, metad
 };
 
 exports.OrphanServiceClient = OrphanServiceClient;
+function OrphanServicePromisesClient(serviceHost, options) {
+  this.client = new OrphanServiceClient(serviceHost, options);
+}
+
+OrphanServicePromisesClient.prototype.doUnary = function doUnary(requestMessage) {
+  var client = this.client;
+  return new Promise(function (resolve, reject) {
+    client.doUnary(requestMessage, function(error, responseMessage) {
+      if (error !== null) {
+        reject(error);
+      } else {
+        resolve(responseMessage);
+      }
+    });
+  });
+};
+
+
+exports.OrphanServicePromisesClient = OrphanServicePromisesClient;
 


### PR DESCRIPTION
A simple way of generating clients that can be used in a more idiomatic (promise-based) way. Missing things like support for methods other than unary, and passing metadata.

This may not be ready for merging into master, but supports my needs at the moment, so I may be using this fork for a while.