### PR TITLE
Add option to general Service Clients or just Stubs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,38 @@ The `generated` folder will now contain both `pb_service.js` and `pb_service.d.t
 **Note** Note that these modules require a CommonJS environment. If you intend to consume these stubs in a browser environment you will need to use a module bundler such as [webpack](https://webpack.js.org/).
 **Note** Both `js` and `d.ts` service files will be generated regardless of whether there are service definitions in the proto files.
 
+#### Service Client Usage
+```js
+import {
+  UserServiceClient,
+  GetUserRequest
+} from "../generated/users_pb_service";
+
+const client = new UserServiceClient("https://my.grpc/server");
+const request = new GetUserRequest();
+request.setUsername("johndoe");
+client.getUser(response, (err, user) => {
+  /* ... */
+});
+```
+
+#### Service Stub Usage
+```ts
+import { grpc } from "@improbable-eng/grpc-web";
+import { GetUserRequest } from "../generated/users_pb_service";
+
+grpc.invoke(GetUserRequest, {
+    request: requestMessage,
+    host: "https://my.grpc/server"
+    onMessage: function (responseMessage) {
+        /* ... */
+    },
+    onEnd: function (status, statusMessage, trailers) {
+        /* ... */
+    }
+});
+```
+
 ## Examples
 
 For a sample of the generated protos and service definitions, see [examples](https://github.com/improbable-eng/ts-protoc-gen/tree/master/examples).

--- a/README.md
+++ b/README.md
@@ -178,13 +178,18 @@ const msg = new MyMessage();
 msg.setName("John Doe");
 ```
 
-### Generating gRPC Service Stubs for use with grpc-web
+### Generating gRPC Service Stubs/Clients for use with grpc-web
 
 [gRPC](https://grpc.io/) is a framework that enables client and server applications to communicate transparently, and makes it easier to build connected systems.
 
 [grpc-web](https://github.com/improbable-eng/grpc-web) is a comparability layer on both the server and client-side which allows gRPC to function natively in modern web-browsers.
 
-To generate client-side service stubs from your protobuf files you must configure ts-protoc-gen to emit service definitions by passing the `service=true` param to the `--ts_out` flag, eg:
+To generate client-side service client/stubs from your protobuf files you must configure ts-protoc-gen to emit service definitions by passing one of `service=client`, or `service=stub` as a param to the `--ts_out` flag.
+
+| parameter | result |
+|-----------|--------|
+| service=client | standalone grpc-web clients are generated which can be imported and used directly; these are more convenient but result in a larger generated file-size |
+| service=stub | minimal grpc-web stubs are generated which can be invoked via the grpc-web package; this produces the minimal file-size overhead |
 
 ```
 # Path to this plugin, Note this must be an abolsute path on Windows (see #15)
@@ -196,7 +201,7 @@ OUT_DIR="./generated"
 protoc \
     --plugin="protoc-gen-ts=${PROTOC_GEN_TS_PATH}" \
     --js_out="import_style=commonjs,binary:${OUT_DIR}" \
-    --ts_out="service=true:${OUT_DIR}" \
+    --ts_out="service=client:${OUT_DIR}" \
     users.proto base.proto
 ```
 
@@ -204,20 +209,6 @@ The `generated` folder will now contain both `pb_service.js` and `pb_service.d.t
 
 **Note** Note that these modules require a CommonJS environment. If you intend to consume these stubs in a browser environment you will need to use a module bundler such as [webpack](https://webpack.js.org/).
 **Note** Both `js` and `d.ts` service files will be generated regardless of whether there are service definitions in the proto files.
-
-```js
-import {
-  UserServiceClient,
-  GetUserRequest
-} from "../generated/users_pb_service";
-
-const client = new UserServiceClient("https://my.grpc/server");
-const req = new GetUserRequest();
-req.setUsername("johndoe");
-client.getUser(req, (err, user) => {
-  /* ... */
-});
-```
 
 ## Examples
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -94,7 +94,7 @@ def typescript_proto_library_aspect_(target, ctx):
     protoc_command = "%s" % (ctx.file._protoc.path)
 
     protoc_command += " --plugin=protoc-gen-ts=%s" % (ctx.files._ts_protoc_gen[1].path)
-    protoc_command += " --ts_out=service=true:%s" % (protoc_output_dir)
+    protoc_command += " --ts_out=service=client:%s" % (protoc_output_dir)
     protoc_command += " --js_out=import_style=commonjs,binary:%s" % (protoc_output_dir)
     protoc_command += " --descriptor_set_in=%s" % (":".join(descriptor_sets_paths))
     protoc_command += " %s" % (" ".join(proto_inputs))

--- a/generate.sh
+++ b/generate.sh
@@ -49,7 +49,7 @@ mkdir -p "$EXAMPLES_GENERATED_DIR"
 $PROTOC \
   --plugin=protoc-gen-ts=./bin/protoc-gen-ts \
   --js_out=import_style=commonjs,binary:$EXAMPLES_GENERATED_DIR \
-  --ts_out=service=true:$EXAMPLES_GENERATED_DIR \
+  --ts_out=service=client:$EXAMPLES_GENERATED_DIR \
   ./proto/othercom/*.proto \
   ./proto/examplecom/*.proto \
   ./proto/*.proto

--- a/test/integration/service/grpcweb.ts
+++ b/test/integration/service/grpcweb.ts
@@ -115,7 +115,7 @@ describe("service/grpc-web", () => {
 
   });
 
-  describe("grpc-web service stubs", () => {
+  describe("grpc-web service clients", () => {
     function makeClient(transportBuilder: StubTransportBuilder): SimpleServiceClient {
       return new SimpleServiceClient("http://localhost:1", {
         transport: transportBuilder.build(),
@@ -130,7 +130,7 @@ describe("service/grpc-web", () => {
       });
     }
 
-    it("should generate a service stub", () => {
+    it("should generate a service client", () => {
       assert.typeOf(SimpleServiceClient, "function", "SimpleServiceClient class shoudl exist");
 
       const client = new SimpleServiceClient("http://localhost:1");


### PR DESCRIPTION
## Changes
Allow consumers to choose if they wish to generate full Service Clients (for use with grpc-web) or just the minimal boilerplate (stubs) required when invoking grpc-web directly.

The primary driver here is to reduce overall bundle-size. Tree shaking is not an option as the generated code use CommonJS modules, not ES6 ones.

## Verification
- Manual verification.
