### PR TITLE
Swap onStatus to invoke BEFORE onEnd rather than after

### DIFF
--- a/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.d.ts
@@ -69,14 +69,14 @@ interface UnaryResponse {
 interface ResponseStream<T> {
   cancel(): void;
   on(type: 'data', handler: (message: T) => void): ResponseStream<T>;
-  on(type: 'end', handler: () => void): ResponseStream<T>;
+  on(type: 'end', handler: (status?: Status) => void): ResponseStream<T>;
   on(type: 'status', handler: (status: Status) => void): ResponseStream<T>;
 }
 interface RequestStream<T> {
   write(message: T): RequestStream<T>;
   end(): void;
   cancel(): void;
-  on(type: 'end', handler: () => void): RequestStream<T>;
+  on(type: 'end', handler: (status?: Status) => void): RequestStream<T>;
   on(type: 'status', handler: (status: Status) => void): RequestStream<T>;
 }
 interface BidirectionalStream<ReqT, ResT> {
@@ -84,7 +84,7 @@ interface BidirectionalStream<ReqT, ResT> {
   end(): void;
   cancel(): void;
   on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;
-  on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'end', handler: (status?: Status) => void): BidirectionalStream<ReqT, ResT>;
   on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;
 }
 

--- a/examples/generated/proto/examplecom/simple_service_pb_service.js
+++ b/examples/generated/proto/examplecom/simple_service_pb_service.js
@@ -113,10 +113,10 @@ SimpleServiceClient.prototype.doServerStream = function doServerStream(requestMe
       });
     },
     onEnd: function (status, statusMessage, trailers) {
-      listeners.end.forEach(function (handler) {
-        handler();
-      });
       listeners.status.forEach(function (handler) {
+        handler({ code: status, details: statusMessage, metadata: trailers });
+      });
+      listeners.end.forEach(function (handler) {
         handler({ code: status, details: statusMessage, metadata: trailers });
       });
       listeners = null;
@@ -145,10 +145,10 @@ SimpleServiceClient.prototype.doClientStream = function doClientStream(metadata)
     transport: this.options.transport
   });
   client.onEnd(function (status, statusMessage, trailers) {
-    listeners.end.forEach(function (handler) {
-      handler();
-    });
     listeners.status.forEach(function (handler) {
+      handler({ code: status, details: statusMessage, metadata: trailers });
+    });
+    listeners.end.forEach(function (handler) {
       handler({ code: status, details: statusMessage, metadata: trailers });
     });
     listeners = null;
@@ -187,10 +187,10 @@ SimpleServiceClient.prototype.doBidiStream = function doBidiStream(metadata) {
     transport: this.options.transport
   });
   client.onEnd(function (status, statusMessage, trailers) {
-    listeners.end.forEach(function (handler) {
-      handler();
-    });
     listeners.status.forEach(function (handler) {
+      handler({ code: status, details: statusMessage, metadata: trailers });
+    });
+    listeners.end.forEach(function (handler) {
       handler({ code: status, details: statusMessage, metadata: trailers });
     });
     listeners = null;

--- a/examples/generated/proto/orphan_pb_service.d.ts
+++ b/examples/generated/proto/orphan_pb_service.d.ts
@@ -37,14 +37,14 @@ interface UnaryResponse {
 interface ResponseStream<T> {
   cancel(): void;
   on(type: 'data', handler: (message: T) => void): ResponseStream<T>;
-  on(type: 'end', handler: () => void): ResponseStream<T>;
+  on(type: 'end', handler: (status?: Status) => void): ResponseStream<T>;
   on(type: 'status', handler: (status: Status) => void): ResponseStream<T>;
 }
 interface RequestStream<T> {
   write(message: T): RequestStream<T>;
   end(): void;
   cancel(): void;
-  on(type: 'end', handler: () => void): RequestStream<T>;
+  on(type: 'end', handler: (status?: Status) => void): RequestStream<T>;
   on(type: 'status', handler: (status: Status) => void): RequestStream<T>;
 }
 interface BidirectionalStream<ReqT, ResT> {
@@ -52,7 +52,7 @@ interface BidirectionalStream<ReqT, ResT> {
   end(): void;
   cancel(): void;
   on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;
-  on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;
+  on(type: 'end', handler: (status?: Status) => void): BidirectionalStream<ReqT, ResT>;
   on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;
 }
 

--- a/examples/generated/proto/orphan_pb_service.js
+++ b/examples/generated/proto/orphan_pb_service.js
@@ -84,10 +84,10 @@ OrphanServiceClient.prototype.doStream = function doStream(requestMessage, metad
       });
     },
     onEnd: function (status, statusMessage, trailers) {
-      listeners.end.forEach(function (handler) {
-        handler();
-      });
       listeners.status.forEach(function (handler) {
+        handler({ code: status, details: statusMessage, metadata: trailers });
+      });
+      listeners.end.forEach(function (handler) {
         handler({ code: status, details: statusMessage, metadata: trailers });
       });
       listeners = null;

--- a/src/service/grpcweb.ts
+++ b/src/service/grpcweb.ts
@@ -211,14 +211,14 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
   printer.printLn(`interface ResponseStream<T> {`);
   printer.printIndentedLn(`cancel(): void;`);
   printer.printIndentedLn(`on(type: 'data', handler: (message: T) => void): ResponseStream<T>;`);
-  printer.printIndentedLn(`on(type: 'end', handler: () => void): ResponseStream<T>;`);
+  printer.printIndentedLn(`on(type: 'end', handler: (status?: Status) => void): ResponseStream<T>;`);
   printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): ResponseStream<T>;`);
   printer.printLn(`}`);
   printer.printLn(`interface RequestStream<T> {`);
   printer.printIndentedLn(`write(message: T): RequestStream<T>;`);
   printer.printIndentedLn(`end(): void;`);
   printer.printIndentedLn(`cancel(): void;`);
-  printer.printIndentedLn(`on(type: 'end', handler: () => void): RequestStream<T>;`);
+  printer.printIndentedLn(`on(type: 'end', handler: (status?: Status) => void): RequestStream<T>;`);
   printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): RequestStream<T>;`);
   printer.printLn(`}`);
   printer.printLn(`interface BidirectionalStream<ReqT, ResT> {`);
@@ -226,7 +226,7 @@ function generateTypescriptDefinition(fileDescriptor: FileDescriptorProto, expor
   printer.printIndentedLn(`end(): void;`);
   printer.printIndentedLn(`cancel(): void;`);
   printer.printIndentedLn(`on(type: 'data', handler: (message: ResT) => void): BidirectionalStream<ReqT, ResT>;`);
-  printer.printIndentedLn(`on(type: 'end', handler: () => void): BidirectionalStream<ReqT, ResT>;`);
+  printer.printIndentedLn(`on(type: 'end', handler: (status?: Status) => void): BidirectionalStream<ReqT, ResT>;`);
   printer.printIndentedLn(`on(type: 'status', handler: (status: Status) => void): BidirectionalStream<ReqT, ResT>;`);
   printer.printLn(`}`);
   printer.printEmptyLn();
@@ -375,10 +375,10 @@ function printServerStreamStubMethod(printer: CodePrinter, method: RPCMethodDesc
         .dedent().printLn(`});`)
       .dedent().printLn(`},`)
                .printLn(`onEnd: function (status, statusMessage, trailers) {`)
-        .indent().printLn(`listeners.end.forEach(function (handler) {`)
-          .indent().printLn(`handler();`)
+        .indent().printLn(`listeners.status.forEach(function (handler) {`)
+          .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
         .dedent().printLn(`});`)
-                 .printLn(`listeners.status.forEach(function (handler) {`)
+                 .printLn(`listeners.end.forEach(function (handler) {`)
           .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
         .dedent().printLn(`});`)
                  .printLn(`listeners = null;`)
@@ -410,10 +410,10 @@ function printClientStreamStubMethod(printer: CodePrinter, method: RPCMethodDesc
                .printLn(`transport: this.options.transport`)
     .dedent().printLn(`});`)
              .printLn(`client.onEnd(function (status, statusMessage, trailers) {`)
-      .indent().printLn(`listeners.end.forEach(function (handler) {`)
-        .indent().printLn(`handler();`)
+      .indent().printLn(`listeners.status.forEach(function (handler) {`)
+        .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
       .dedent().printLn(`});`)
-               .printLn(`listeners.status.forEach(function (handler) {`)
+               .printLn(`listeners.end.forEach(function (handler) {`)
         .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
       .dedent().printLn(`});`)
                .printLn(`listeners = null;`)
@@ -455,10 +455,10 @@ function printBidirectionalStubMethod(printer: CodePrinter, method: RPCMethodDes
                .printLn(`transport: this.options.transport`)
     .dedent().printLn(`});`)
              .printLn(`client.onEnd(function (status, statusMessage, trailers) {`)
-      .indent().printLn(`listeners.end.forEach(function (handler) {`)
-        .indent().printLn(`handler();`)
+      .indent().printLn(`listeners.status.forEach(function (handler) {`)
+        .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
       .dedent().printLn(`});`)
-               .printLn(`listeners.status.forEach(function (handler) {`)
+               .printLn(`listeners.end.forEach(function (handler) {`)
         .indent().printLn(`handler({ code: status, details: statusMessage, metadata: trailers });`)
       .dedent().printLn(`});`)
                .printLn(`listeners = null;`)

--- a/test/integration/service/grpcweb.ts
+++ b/test/integration/service/grpcweb.ts
@@ -230,17 +230,17 @@ describe("service/grpc-web", () => {
           });
       });
 
-      it("should invoke onEnd before onStatus", (done) => {
+      it("should invoke onStatus before onEnd", (done) => {
         const [payload] = makePayloads("some value");
-        let onEndInvoked = false;
+        let onStatusInvoked = false;
 
         makeClient(new StubTransportBuilder().withMessages([payload]))
           .doServerStream(new StreamRequest())
-          .on("end", () => { onEndInvoked = true; })
-          .on("status", () => {
-            assert.ok(onEndInvoked, "onEnd callback should be invoked before onStatus");
+          .on("end", () => {
+            assert.ok(onStatusInvoked, "onStatus callback should be invoked before onEnd");
             done();
-          });
+          })
+          .on("status", () => { onStatusInvoked = true; });
       });
 
       it("should handle an error returned ahead of any data by the endpoint", (done) => {
@@ -362,15 +362,17 @@ describe("service/grpc-web", () => {
           .end();
       });
 
-      it("should invoke onEnd before onStatus", (done) => {
-        let onEndInvoked = false;
+      it("should invoke onStatus before onEnd", (done) => {
+        let onStatusInvoked = false;
 
         makeClient(new StubTransportBuilder())
           .doClientStream()
-          .on("end", () => { onEndInvoked = true; })
-          .on("status", () => {
-            assert.ok(onEndInvoked, "onEnd callback should be invoked before onStatus");
+          .on("end", () => {
+            assert.ok(onStatusInvoked, "onStatus callback should be invoked before onEnd");
             done();
+          })
+          .on("status", () => {
+            onStatusInvoked = true;
           })
           .write(payload)
           .end();
@@ -467,16 +469,16 @@ describe("service/grpc-web", () => {
           .end();
       });
 
-      it("should invoke onEnd before onStatus if the client ends the stream", (done) => {
-        let onEndInvoked = false;
+      it("should invoke onStatus before onEnd if the client ends the stream", (done) => {
+        let onStatusInvoked = false;
 
         makeClient(new StubTransportBuilder())
           .doBidiStream()
-          .on("end", () => { onEndInvoked = true; })
-          .on("status", () => {
-            assert.ok(onEndInvoked, "onEnd callback should be invoked before onStatus");
+          .on("end", () => {
+            assert.ok(onStatusInvoked, "onStatus callback should be invoked before onEnd");
             done();
           })
+          .on("status", () => { onStatusInvoked = true; })
           .write(payload)
           .end();
       });
@@ -493,15 +495,17 @@ describe("service/grpc-web", () => {
           .end();
       });
 
-      it("should invoke onEnd before onStatus if the server ends the stream", (done) => {
-        let onEndInvoked = false;
+      it("should invoke onStatus before onEnd if the server ends the stream", (done) => {
+        let onStatusInvoked = false;
 
         makeClient(new StubTransportBuilder().withMessages([ payload ]))
           .doBidiStream()
-          .on("end", () => { onEndInvoked = true; })
-          .on("status", () => {
-            assert.ok(onEndInvoked, "onEnd callback should be invoked before onStatus");
+          .on("end", () => {
+            assert.ok(onStatusInvoked, "onStatus callback should be invoked before onEnd");
             done();
+          })
+          .on("status", () => {
+            onStatusInvoked = true;
           });
       });
 


### PR DESCRIPTION
## Changes

implemented changes specified in #155 

## Verification

There were 4 tests that broke with this change because they were explicitly expecting `onEnd` to come before `onStatus`, so I updated those. I also wrote 4 new tests to ensure that the `onEnd` handler is called with a status and that that status matches the one returned from `onStatus`.