### PR TITLE
bugfix/162 - add cloneMessage to typescript definition files

### DIFF
--- a/examples/generated/proto/examplecom/annotations_pb.d.ts
+++ b/examples/generated/proto/examplecom/annotations_pb.d.ts
@@ -20,6 +20,7 @@ export class AnnotatedMessage extends jspb.Message {
   setMysfixed64(value: string): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): AnnotatedMessage;
   toObject(includeInstance?: boolean): AnnotatedMessage.AsObject;
   static toObject(includeInstance: boolean, msg: AnnotatedMessage): AnnotatedMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/empty_message_no_service_pb.d.ts
+++ b/examples/generated/proto/examplecom/empty_message_no_service_pb.d.ts
@@ -5,6 +5,7 @@ import * as jspb from "google-protobuf";
 
 export class NoService extends jspb.Message {
   serializeBinary(): Uint8Array;
+  cloneMessage(): NoService;
   toObject(includeInstance?: boolean): NoService.AsObject;
   static toObject(includeInstance: boolean, msg: NoService): NoService.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/enum_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/enum_message_pb.d.ts
@@ -22,6 +22,7 @@ export class EnumMessage extends jspb.Message {
   addExternalEnums(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap], index?: number): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): EnumMessage;
   toObject(includeInstance?: boolean): EnumMessage.AsObject;
   static toObject(includeInstance: boolean, msg: EnumMessage): EnumMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/map_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/map_message_pb.d.ts
@@ -17,6 +17,7 @@ export class MapMessage extends jspb.Message {
   getPrimitiveIntsMap(): jspb.Map<string, number>;
   clearPrimitiveIntsMap(): void;
   serializeBinary(): Uint8Array;
+  cloneMessage(): MapMessage;
   toObject(includeInstance?: boolean): MapMessage.AsObject;
   static toObject(includeInstance: boolean, msg: MapMessage): MapMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -40,6 +41,7 @@ export namespace MapMessage {
     setMyString(value: string): void;
 
     serializeBinary(): Uint8Array;
+    cloneMessage(): InternalChildMessage;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
     static toObject(includeInstance: boolean, msg: InternalChildMessage): InternalChildMessage.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/oneof_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/oneof_message_pb.d.ts
@@ -27,6 +27,7 @@ export class OneOfMessage extends jspb.Message {
 
   getGroupCase(): OneOfMessage.GroupCase;
   serializeBinary(): Uint8Array;
+  cloneMessage(): OneOfMessage;
   toObject(includeInstance?: boolean): OneOfMessage.AsObject;
   static toObject(includeInstance: boolean, msg: OneOfMessage): OneOfMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -49,6 +50,7 @@ export namespace OneOfMessage {
     setMyString(value: string): void;
 
     serializeBinary(): Uint8Array;
+    cloneMessage(): InternalChildMessage;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
     static toObject(includeInstance: boolean, msg: InternalChildMessage): InternalChildMessage.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -86,6 +88,7 @@ export class CamelCasedOneOfMessage extends jspb.Message {
 
   getCamelcasedmessageCase(): CamelCasedOneOfMessage.CamelcasedmessageCase;
   serializeBinary(): Uint8Array;
+  cloneMessage(): CamelCasedOneOfMessage;
   toObject(includeInstance?: boolean): CamelCasedOneOfMessage.AsObject;
   static toObject(includeInstance: boolean, msg: CamelCasedOneOfMessage): CamelCasedOneOfMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -121,6 +124,7 @@ export class SnakeCasedOneOfMessage extends jspb.Message {
 
   getSnakeCasedMessageCase(): SnakeCasedOneOfMessage.SnakeCasedMessageCase;
   serializeBinary(): Uint8Array;
+  cloneMessage(): SnakeCasedOneOfMessage;
   toObject(includeInstance?: boolean): SnakeCasedOneOfMessage.AsObject;
   static toObject(includeInstance: boolean, msg: SnakeCasedOneOfMessage): SnakeCasedOneOfMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/parent_message_v2_pb.d.ts
+++ b/examples/generated/proto/examplecom/parent_message_v2_pb.d.ts
@@ -36,6 +36,7 @@ export class ParentMessageV2 extends jspb.Message {
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): ParentMessageV2;
   toObject(includeInstance?: boolean): ParentMessageV2.AsObject;
   static toObject(includeInstance: boolean, msg: ParentMessageV2): ParentMessageV2.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -62,6 +63,7 @@ export namespace ParentMessageV2 {
     setMyString(value: string): void;
 
     serializeBinary(): Uint8Array;
+    cloneMessage(): InternalChildMessage;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
     static toObject(includeInstance: boolean, msg: InternalChildMessage): InternalChildMessage.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
@@ -26,6 +26,7 @@ export class ParentMessageV3 extends jspb.Message {
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): ParentMessageV3;
   toObject(includeInstance?: boolean): ParentMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: ParentMessageV3): ParentMessageV3.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -48,6 +49,7 @@ export namespace ParentMessageV3 {
     setMyString(value: string): void;
 
     serializeBinary(): Uint8Array;
+    cloneMessage(): InternalChildMessage;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
     static toObject(includeInstance: boolean, msg: InternalChildMessage): InternalChildMessage.AsObject;
     static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/primitive_message_v2_pb.d.ts
+++ b/examples/generated/proto/examplecom/primitive_message_v2_pb.d.ts
@@ -164,6 +164,7 @@ export class PrimitiveMessageV2 extends jspb.Message {
   setOptNumber(value: number): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): PrimitiveMessageV2;
   toObject(includeInstance?: boolean): PrimitiveMessageV2.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV2): PrimitiveMessageV2.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -55,6 +55,7 @@ export class PrimitiveMessageV3 extends jspb.Message {
   setMyNumber(value: number): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): PrimitiveMessageV3;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV3): PrimitiveMessageV3.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/repeated_primitive_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/repeated_primitive_message_pb.d.ts
@@ -82,6 +82,7 @@ export class RepeatedPrimitiveMessage extends jspb.Message {
   addMyBytes(value: Uint8Array | string, index?: number): Uint8Array | string;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): RepeatedPrimitiveMessage;
   toObject(includeInstance?: boolean): RepeatedPrimitiveMessage.AsObject;
   static toObject(includeInstance: boolean, msg: RepeatedPrimitiveMessage): RepeatedPrimitiveMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/reserved_words_pb.d.ts
+++ b/examples/generated/proto/examplecom/reserved_words_pb.d.ts
@@ -179,6 +179,7 @@ export class ReservedWordsMessage extends jspb.Message {
   setWith(value: string): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): ReservedWordsMessage;
   toObject(includeInstance?: boolean): ReservedWordsMessage.AsObject;
   static toObject(includeInstance: boolean, msg: ReservedWordsMessage): ReservedWordsMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/simple_pb.d.ts
+++ b/examples/generated/proto/examplecom/simple_pb.d.ts
@@ -88,6 +88,7 @@ export class MySimple extends jspb.Message {
   setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): MySimple;
   toObject(includeInstance?: boolean): MySimple.AsObject;
   static toObject(includeInstance: boolean, msg: MySimple): MySimple.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/simple_service_pb.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb.d.ts
@@ -16,6 +16,7 @@ export class UnaryRequest extends jspb.Message {
   setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): UnaryRequest;
   toObject(includeInstance?: boolean): UnaryRequest.AsObject;
   static toObject(includeInstance: boolean, msg: UnaryRequest): UnaryRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -34,6 +35,7 @@ export namespace UnaryRequest {
 
 export class UnaryResponse extends jspb.Message {
   serializeBinary(): Uint8Array;
+  cloneMessage(): UnaryResponse;
   toObject(includeInstance?: boolean): UnaryResponse.AsObject;
   static toObject(includeInstance: boolean, msg: UnaryResponse): UnaryResponse.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -53,6 +55,7 @@ export class StreamRequest extends jspb.Message {
   setSomeString(value: string): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): StreamRequest;
   toObject(includeInstance?: boolean): StreamRequest.AsObject;
   static toObject(includeInstance: boolean, msg: StreamRequest): StreamRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated/proto/examplecom/simplevalue_pb.d.ts
@@ -43,6 +43,7 @@ export class SimpleValue extends jspb.Message {
   getKindCase(): SimpleValue.KindCase;
   getAnotherCase(): SimpleValue.AnotherCase;
   serializeBinary(): Uint8Array;
+  cloneMessage(): SimpleValue;
   toObject(includeInstance?: boolean): SimpleValue.AsObject;
   static toObject(includeInstance: boolean, msg: SimpleValue): SimpleValue.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/examplecom/well_known_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/well_known_message_pb.d.ts
@@ -77,6 +77,7 @@ export class WellKnownMessage extends jspb.Message {
   setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): WellKnownMessage;
   toObject(includeInstance?: boolean): WellKnownMessage.AsObject;
   static toObject(includeInstance: boolean, msg: WellKnownMessage): WellKnownMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/orphan_pb.d.ts
+++ b/examples/generated/proto/orphan_pb.d.ts
@@ -7,6 +7,7 @@ export class OrphanMapMessage extends jspb.Message {
   getPrimitiveIntsMap(): jspb.Map<string, number>;
   clearPrimitiveIntsMap(): void;
   serializeBinary(): Uint8Array;
+  cloneMessage(): OrphanMapMessage;
   toObject(includeInstance?: boolean): OrphanMapMessage.AsObject;
   static toObject(includeInstance: boolean, msg: OrphanMapMessage): OrphanMapMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -33,6 +34,7 @@ export class OrphanMessage extends jspb.Message {
   setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): OrphanMessage;
   toObject(includeInstance?: boolean): OrphanMessage.AsObject;
   static toObject(includeInstance: boolean, msg: OrphanMessage): OrphanMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -55,6 +57,7 @@ export class OrphanUnaryRequest extends jspb.Message {
   setSomeInt64(value: number): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): OrphanUnaryRequest;
   toObject(includeInstance?: boolean): OrphanUnaryRequest.AsObject;
   static toObject(includeInstance: boolean, msg: OrphanUnaryRequest): OrphanUnaryRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};
@@ -75,6 +78,7 @@ export class OrphanStreamRequest extends jspb.Message {
   setSomeString(value: string): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): OrphanStreamRequest;
   toObject(includeInstance?: boolean): OrphanStreamRequest.AsObject;
   static toObject(includeInstance: boolean, msg: OrphanStreamRequest): OrphanStreamRequest.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/examples/generated/proto/othercom/external_child_message_pb.d.ts
+++ b/examples/generated/proto/othercom/external_child_message_pb.d.ts
@@ -8,6 +8,7 @@ export class ExternalChildMessage extends jspb.Message {
   setMyString(value: string): void;
 
   serializeBinary(): Uint8Array;
+  cloneMessage(): ExternalChildMessage;
   toObject(includeInstance?: boolean): ExternalChildMessage.AsObject;
   static toObject(includeInstance: boolean, msg: ExternalChildMessage): ExternalChildMessage.AsObject;
   static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};

--- a/src/ts/message.ts
+++ b/src/ts/message.ts
@@ -197,6 +197,7 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
   });
 
   printer.printIndentedLn(`serializeBinary(): Uint8Array;`);
+  printer.printIndentedLn(`cloneMessage(): ${messageName};`);
   printer.printIndentedLn(`toObject(includeInstance?: boolean): ${messageName}.${objectTypeName};`);
   printer.printIndentedLn(`static toObject(includeInstance: boolean, msg: ${messageName}): ${messageName}.${objectTypeName};`);
   printer.printIndentedLn(`static extensions: {[key: number]: jspb.ExtensionFieldInfo<jspb.Message>};`);


### PR DESCRIPTION
## Changes
- Added 1 line to src/ts/message that adds a cloneMessage call, using the Message name as the return type

## Verification
- Ran lint, test, and generate against the updated sources
- verified that the examples, also part of the commit, included the cloneMessage definition
