### PR TITLE
Replace deprecated `new Buffer()` with `Buffer.from()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ withAllStdIn((inputBuff: Buffer) => {
       }
     });
 
-    process.stdout.write(new Buffer(codeGenResponse.serializeBinary()));
+    process.stdout.write(Buffer.from(codeGenResponse.serializeBinary()));
   } catch (err) {
     console.error("protoc-gen-ts error: " + err.stack + "\n");
     process.exit(1);


### PR DESCRIPTION
`new Buffer()` is deprecated, use `Buffer.from()` instead.

Fixes #164 