### PR TITLE
Splitting out JS code generation into its own rule

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -4,10 +4,15 @@ load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
 
 TypescriptProtoLibraryAspect = provider(
     fields = {
-        "js_outputs": "The JS output files produced directly from the src protos",
         "dts_outputs": "Ths TS definition files produced directly from the src protos",
-        "deps_js": "The transitive JS dependencies",
         "deps_dts": "The transitive dependencies' TS definitions",
+    },
+)
+
+JavascriptProtoLibraryAspect = provider(
+    fields = {
+        "js_outputs": "The JS output files produced directly from the src protos",
+        "deps_js": "The transitive JS dependencies",
     },
 )
 
@@ -29,22 +34,14 @@ def proto_path(proto):
         path = path[1:]
     return path
 
-def append_to_outputs(ctx, file_name, js_outputs, dts_outputs, file_modifications):
-    generated_filenames = ["_pb.d.ts", "_pb.js", "_pb_service.js", "_pb_service.d.ts"]
-
-    for f in generated_filenames:
-        output = ctx.actions.declare_file(file_name + f)
-        if f.endswith(".d.ts"):
-            dts_outputs.append(output)
-        else:
-            js_outputs.append(output)
-
 def _convert_js_files_to_amd_modules(ctx, js_outputs):
     """
     Converts the output js into an AMD module, similar to how it is done in rules_typecript:
       https://github.com/bazelbuild/rules_typescript/blob/master/internal/protobufjs/typescript_proto_library_aspectrary.bzl#L47
-    """
 
+    NOTE: This only works on Linux. This should be factored out into a binary that can be
+    called as a part of this rule or as its own rule.
+    """
     amd_module_conversions = []
     for js_file in js_outputs:
         file_path = "/".join([p for p in [
@@ -59,19 +56,17 @@ def _convert_js_files_to_amd_modules(ctx, js_outputs):
         cmd += " && sed -i -E 's/(require\(.*).js/\\1/' %s" % (js_file.path)
         amd_module_conversions.append(cmd)
 
-    return amd_module_conversions
+        return amd_module_conversions
 
-def typescript_proto_library_aspect_(target, ctx):
+def common_proto_library_impl_(target, ctx, generated_file_endings, custom_flags, progress_message, file_modifications):
     """
     A bazel aspect that is applied on every proto_library rule on the transitive set of dependencies
     of a typescript_proto_library rule.
 
     Handles running protoc to produce the generated JS and TS files.
     """
-    js_outputs = []
-    dts_outputs = []
+    outputs = []
     proto_inputs = []
-    file_modifications = []
 
     inputs = depset([ctx.file._protoc])
     for src in target.proto.direct_sources:
@@ -81,9 +76,9 @@ def typescript_proto_library_aspect_(target, ctx):
         file_name = src.basename[:-len(src.extension) - 1]
         normalized_file = proto_path(src)
         proto_inputs.append(normalized_file)
-        append_to_outputs(ctx, file_name, js_outputs, dts_outputs, file_modifications)
-
-    outputs = dts_outputs + js_outputs
+        for f in generated_file_endings:
+            output = ctx.actions.declare_file(file_name + f)
+            outputs.append(output)
 
     inputs += ctx.files._ts_protoc_gen
     inputs += target.proto.direct_sources
@@ -91,45 +86,99 @@ def typescript_proto_library_aspect_(target, ctx):
 
     descriptor_sets_paths = [desc.path for desc in target.proto.transitive_descriptor_sets]
 
-    protoc_output_dir = ctx.var["BINDIR"]
     protoc_command = "%s" % (ctx.file._protoc.path)
+    default_flags = [
+        " --plugin=protoc-gen-ts=%s" % (ctx.files._ts_protoc_gen[1].path),
+        " --ts_out=service=true:%s" % (ctx.var["BINDIR"]),
+        " --descriptor_set_in=%s" % (":".join(descriptor_sets_paths)),
+    ]
 
-    protoc_command += " --plugin=protoc-gen-ts=%s" % (ctx.files._ts_protoc_gen[1].path)
-    protoc_command += " --ts_out=service=true:%s" % (protoc_output_dir)
-    protoc_command += " --js_out=import_style=commonjs,binary:%s" % (protoc_output_dir)
-    protoc_command += " --descriptor_set_in=%s" % (":".join(descriptor_sets_paths))
-    protoc_command += " %s" % (" ".join(proto_inputs))
+    protoc_flags = " ".join(default_flags + custom_flags)
+    protoc_arguments = " ".join(proto_inputs)
+    protoc_command += " %s %s" % (protoc_flags, protoc_arguments)
 
-    amd_module_conversions = _convert_js_files_to_amd_modules(ctx, js_outputs)
+    # For now, this will provide modifications in the form of commands that will be appended onto
+    # the main command. In the future, this should be separated out to use a tool and have its own
+    # rule that has inputs and outputs too.
+    file_modification_commands = []
+    for modify_file in file_modifications:
+        file_modification_commands += modify_file(ctx, outputs)
 
-    commands = [protoc_command] + file_modifications + amd_module_conversions
+    commands = [protoc_command] + file_modification_commands
     command = " && ".join(commands)
+
     ctx.actions.run_shell(
         inputs = inputs,
         outputs = outputs,
-        progress_message = "Creating Typescript pb files %s" % ctx.label,
-        command = command,
+        progress_message = progress_message,
+        command = command
     )
 
-    dts_outputs = depset(dts_outputs)
-    js_outputs = depset(js_outputs)
-    deps_js = depset([])
-    deps_dts = depset([])
+    outputs = depset(outputs)
+    deps = depset([])
+
+    return outputs, deps
+
+def typescript_proto_library_aspect_(target, ctx):
+    outputs, deps = common_proto_library_impl_(
+        target,
+        ctx,
+        ["_pb.d.ts", "_pb_service.d.ts"],
+        [],
+        "Creating Typescript pb files %s" % ctx.label,
+        []
+    )
 
     for dep in ctx.rule.attr.deps:
         aspect_data = dep[TypescriptProtoLibraryAspect]
-        deps_dts += aspect_data.dts_outputs + aspect_data.deps_dts
-        deps_js += aspect_data.js_outputs + aspect_data.deps_js
+        deps += aspect_data.dts_outputs + aspect_data.deps_dts
 
     return [TypescriptProtoLibraryAspect(
-        dts_outputs = dts_outputs,
-        js_outputs = js_outputs,
-        deps_dts = deps_dts,
-        deps_js = deps_js,
+        dts_outputs = outputs,
+        deps_dts = deps,
+    )]
+
+def javascript_proto_library_aspect_(target, ctx):
+    outputs, deps = common_proto_library_impl_(
+        target,
+        ctx,
+        ["_pb.js", "_pb_service.js"],
+        [" --js_out=import_style=commonjs,binary:%s" % (ctx.var["BINDIR"])],
+        "Creating Javascript pb files %s" % ctx.label,
+        [_convert_js_files_to_amd_modules]
+    )
+
+    for dep in ctx.rule.attr.deps:
+        aspect_data = dep[JavascriptProtoLibraryAspect]
+        deps += aspect_data.js_outputs + aspect_data.deps_js
+
+    return [JavascriptProtoLibraryAspect(
+        js_outputs = outputs,
+        deps_js = deps,
     )]
 
 typescript_proto_library_aspect = aspect(
     implementation = typescript_proto_library_aspect_,
+    attr_aspects = ["deps"],
+    attrs = {
+        "_ts_protoc_gen": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "host",
+            default = Label("@ts_protoc_gen//bin:protoc-gen-ts"),
+        ),
+        "_protoc": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = Label("@com_google_protobuf//:protoc"),
+        ),
+    },
+)
+
+javascript_proto_library_aspect = aspect(
+    implementation = javascript_proto_library_aspect_,
     attr_aspects = ["deps"],
     attrs = {
         "_ts_protoc_gen": attr.label(
@@ -153,19 +202,17 @@ def _typescript_proto_library_impl(ctx):
     Handles converting the aspect output into a provider compatible with the rules_typescript rules.
     """
     aspect_data = ctx.attr.proto[TypescriptProtoLibraryAspect]
-    dts_outputs = aspect_data.dts_outputs
-    js_outputs = aspect_data.js_outputs
-    outputs = js_outputs + dts_outputs
+    outputs = aspect_data.dts_outputs
 
     return struct(
         typescript = struct(
-            declarations = dts_outputs,
-            transitive_declarations = dts_outputs + aspect_data.deps_dts,
+            declarations = outputs,
+            transitive_declarations = outputs + aspect_data.deps_dts,
             type_blacklisted_declarations = depset([]),
-            es5_sources = js_outputs + aspect_data.deps_js,
-            es6_sources = js_outputs + aspect_data.deps_js,
-            transitive_es5_sources = js_outputs + aspect_data.deps_js,
-            transitive_es6_sources = js_outputs + aspect_data.deps_js,
+            es5_sources = depset([]),
+            es6_sources = depset([]),
+            transitive_es5_sources = depset([]),
+            transitive_es6_sources = depset([]),
         ),
         legacy_info = struct(
             files = outputs,
@@ -199,6 +246,57 @@ typescript_proto_library = rule(
         ),
     },
     implementation = _typescript_proto_library_impl,
+)
+
+def _javascript_proto_library_impl(ctx):
+    """
+    Handles converting the aspect output into a provider compatible with the rules_typescript rules.
+    """
+    aspect_data = ctx.attr.proto[JavascriptProtoLibraryAspect]
+    outputs = aspect_data.js_outputs
+
+    return struct(
+        typescript = struct(
+            declarations = outputs,
+            transitive_declarations = outputs + aspect_data.deps_js,
+            type_blacklisted_declarations = depset([]),
+            es5_sources = outputs + aspect_data.deps_js,
+            es6_sources = outputs + aspect_data.deps_js,
+            transitive_es5_sources = outputs + aspect_data.deps_js,
+            transitive_es6_sources = outputs + aspect_data.deps_js,
+        ),
+        legacy_info = struct(
+            files = outputs,
+        ),
+        providers = [
+            DefaultInfo(files = outputs),
+        ],
+    )
+
+javascript_proto_library = rule(
+    attrs = {
+        "proto": attr.label(
+            mandatory = True,
+            allow_files = True,
+            single_file = True,
+            providers = ["proto"],
+            aspects = [javascript_proto_library_aspect],
+        ),
+        "_ts_protoc_gen": attr.label(
+            allow_files = True,
+            executable = True,
+            cfg = "host",
+            default = Label("@ts_protoc_gen//bin:protoc-gen-ts"),
+        ),
+        "_protoc": attr.label(
+            allow_files = True,
+            single_file = True,
+            executable = True,
+            cfg = "host",
+            default = Label("@com_google_protobuf//:protoc"),
+        ),
+    },
+    implementation = _javascript_proto_library_impl,
 )
 
 def typescript_proto_dependencies():

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@ts_protoc_gen//:defs.bzl", "typescript_proto_library")
+load("@ts_protoc_gen//:defs.bzl", "javascript_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,4 +18,9 @@ proto_library(
 typescript_proto_library(
     name = "generate",
     proto = ":proto",
+)
+
+javascript_proto_library(
+  name = "generate_js",
+  proto = ":proto",
 )

--- a/proto/examplecom/BUILD.bazel
+++ b/proto/examplecom/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@ts_protoc_gen//:defs.bzl", "typescript_proto_library")
+load("@ts_protoc_gen//:defs.bzl", "javascript_proto_library")
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -30,5 +31,10 @@ proto_library(
 
 typescript_proto_library(
   name = "generate",
+  proto = ":proto",
+)
+
+javascript_proto_library(
+  name = "generate_js",
   proto = ":proto",
 )

--- a/proto/othercom/BUILD.bazel
+++ b/proto/othercom/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@ts_protoc_gen//:defs.bzl", "typescript_proto_library")
+load("@ts_protoc_gen//:defs.bzl", "javascript_proto_library")
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -15,5 +16,10 @@ proto_library(
 
 typescript_proto_library(
   name = "generate",
+  proto = ":proto",
+)
+
+javascript_proto_library(
+  name = "generate_js",
   proto = ":proto",
 )

--- a/test/bazel/proto/BUILD.bazel
+++ b/test/bazel/proto/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//test/bazel:__subpackages__"])
 
 load("//:defs.bzl", "typescript_proto_library")
+load("//:defs.bzl", "javascript_proto_library")
 
 proto_library(
     name = "pizza_service_proto",
@@ -15,5 +16,10 @@ proto_library(
 
 typescript_proto_library(
     name = "pizza_service_ts_proto",
+    proto = ":pizza_service_proto",
+)
+
+javascript_proto_library(
+    name = "pizza_service_js_proto",
     proto = ":pizza_service_proto",
 )

--- a/test/bazel/proto/common/BUILD.bazel
+++ b/test/bazel/proto/common/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//test/bazel:__subpackages__"])
 
 load("//:defs.bzl", "typescript_proto_library")
+load("//:defs.bzl", "javascript_proto_library")
 
 proto_library(
     name = "delivery_person_proto",
@@ -17,6 +18,11 @@ typescript_proto_library(
     proto = ":delivery_person_proto",
 )
 
+javascript_proto_library(
+    name = "delivery_person_jss_proto",
+    proto = ":delivery_person_proto",
+)
+
 proto_library(
     name = "pizza_proto",
     srcs = [
@@ -27,4 +33,9 @@ proto_library(
 typescript_proto_library(
     name = "pizza_ts_proto",
     proto = ":pizza_proto",
+)
+
+javascript_proto_library(
+  name = "pizza_js_proto",
+  proto = ":pizza_proto",
 )


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

In order to unblock development on Mac, I'm splitting out the Javascript code generation into its own rule. This seems like a generally good thing, and it allows for another rule for AMD module generation to cleanly be added on.

## Verification

Built (after locally fixing the sed issues described in #166) and it succeeded. Building on Mac excluding the new `javascript_library` rules also works.

Ran `yarn test` successfully.

<!-- How you tested it? How do you know it works? -->
