### PR TITLE
Support bazel external protos such as google well known types

### DIFF
--- a/test/bazel/BUILD.bazel
+++ b/test/bazel/BUILD.bazel
@@ -47,6 +47,7 @@ ts_library(
     deps = [
         "//test/bazel/proto:pizza_service_ts_proto",
         "//test/bazel/proto/common:pizza_ts_proto",
+        "@npm//@types/google-protobuf",
         "@npm//@types/jasmine",
         # Don't put delivery_person_ts_proto here, we want to test it is included transitively
     ],
@@ -69,4 +70,7 @@ ts_web_test_suite(
         ":google_protobuf_requirejs",
         ":pizza_service_proto_test",
     ],
+    data = [
+        "@npm//google-protobuf",
+    ]
 )

--- a/test/bazel/pizza_service_proto_test.spec.ts
+++ b/test/bazel/pizza_service_proto_test.spec.ts
@@ -4,6 +4,7 @@ import {
   OrderPizzaResponse
 } from "ts_protoc_gen/test/bazel/proto/pizza_service_pb";
 import {PizzaService} from "ts_protoc_gen/test/bazel/proto/pizza_service_pb_service";
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 
 declare function require(module: string): any;
 
@@ -38,4 +39,24 @@ describe("DeliveryPerson", () => {
 
     expect(person.getPizzasList().length).toBe(1);
   });
+
+  it("Timestamp seems to work", () => {
+    const response = new OrderPizzaResponse();
+
+    const PROTOS = require("ts_protoc_gen/test/bazel/proto/common/delivery_person_pb");
+    const DeliveryPerson = PROTOS.DeliveryPerson;
+    const person = new DeliveryPerson();
+    response.setDeliveryPerson(person);
+
+    const ts = new Timestamp();
+    const now = new Date();
+    const minutes = 30;
+    const deliveryTime = new Date(now.getTime() + minutes * 60000);
+    ts.fromDate(deliveryTime);
+    response.setPromisedTime(ts);
+
+    console.log("promised time = " + response.getPromisedTime());
+    expect(response.getPromisedTime()).toBeDefined();
+  });
+
 });

--- a/test/bazel/proto/BUILD.bazel
+++ b/test/bazel/proto/BUILD.bazel
@@ -10,6 +10,7 @@ proto_library(
     deps = [
         "//test/bazel/proto/common:delivery_person_proto",
         "//test/bazel/proto/common:pizza_proto",
+        "@com_google_protobuf//:timestamp_proto",
     ],
 )
 

--- a/test/bazel/proto/pizza_service.proto
+++ b/test/bazel/proto/pizza_service.proto
@@ -5,6 +5,8 @@ package test.bazel.proto;
 import "test/bazel/proto/common/pizza.proto";
 import "test/bazel/proto/common/delivery_person.proto";
 
+import "google/protobuf/timestamp.proto";
+
 service PizzaService {
   rpc OrderPizza(OrderPizzaRequest) returns (OrderPizzaResponse) {}
 }
@@ -18,4 +20,6 @@ message OrderPizzaRequest {
 message OrderPizzaResponse {
   // The person that will deliver the pizza.
   DeliveryPerson delivery_person = 1;
+  // Time the delivery should arrive by.
+  google.protobuf.Timestamp promised_time = 2;
 }


### PR DESCRIPTION
## Changes

- when using bazel rules, support "external" proto libs
