### PR TITLE
Bazel Rules: Messages with Numbers

### DIFF
--- a/src/bazel/change_import_style.ts
+++ b/src/bazel/change_import_style.ts
@@ -64,7 +64,7 @@ function processCommonJs(args: any, initialContents: string): string {
   // Rollup can't resolve the commonjs exports when using goog.object.extend so we replace it with:
   // 'exports.MyProto = proto.namespace.MyProto;'
   const replaceGoogExtendWithExports = (contents: string) => {
-    const googSymbolRegex = /goog.exportSymbol\('(.*\.([A-z_]+))',.*;/g;
+    const googSymbolRegex = /goog.exportSymbol\('(.*\.([A-z0-9_]+))',.*;/g;
     let match;
     const symbols = [];
     while (match = googSymbolRegex.exec(initialContents)) {

--- a/test/bazel/BUILD.bazel
+++ b/test/bazel/BUILD.bazel
@@ -85,6 +85,7 @@ ts_library(
     srcs = ["test_bundling.ts"],
     tsconfig = ":test_bundling_tsconfig.json",
     deps = [
+        "//test/bazel/proto:naming_styles_ts_proto",
         "//test/bazel/proto/common:delivery_person_ts_proto",
         "@npm//google-protobuf",
     ],

--- a/test/bazel/proto/BUILD.bazel
+++ b/test/bazel/proto/BUILD.bazel
@@ -3,6 +3,18 @@ package(default_visibility = ["//test/bazel:__subpackages__"])
 load("//:defs.bzl", "typescript_proto_library")
 
 proto_library(
+    name = "naming_styles_proto",
+    srcs = [
+        "naming_styles.proto",
+    ],
+)
+
+typescript_proto_library(
+    name = "naming_styles_ts_proto",
+    proto = ":naming_styles_proto",
+)
+
+proto_library(
     name = "pizza_service_proto",
     srcs = [
         "pizza_service.proto",

--- a/test/bazel/proto/naming_styles.proto
+++ b/test/bazel/proto/naming_styles.proto
@@ -1,0 +1,60 @@
+// This file tests a bunch of valid naming schemes for messages.
+syntax = "proto3";
+
+package test.bazel.proto;
+
+message alllowercase {
+  int64 test = 1;
+}
+
+message ALLUPPERCASE {
+  int64 test = 1;
+}
+
+message lowerCamelCase {
+  int64 test = 1;
+}
+
+message UpperCamelCase {
+  int64 test = 1;
+}
+
+message snake_case_snake_case {
+  int64 test = 1;
+}
+
+message Upper_snake_Case {
+  int64 test = 1;
+}
+
+message M2M {
+  int64 test = 1;
+}
+
+message M_2M {
+  int64 test = 1;
+}
+
+message M2_M {
+  int64 test = 1;
+}
+
+message M2M_ {
+  int64 test = 1;
+}
+
+message m_22M {
+  int64 test = 1;
+}
+
+message m42_M {
+  int64 test = 1;
+}
+
+message m24M_ {
+  int64 test = 1;
+}
+
+message M9 {
+  int64 test = 1;
+}

--- a/test/bazel/test_bundling.ts
+++ b/test/bazel/test_bundling.ts
@@ -1,7 +1,35 @@
 import {DeliveryPerson} from "ts_protoc_gen/test/bazel/proto/common/delivery_person_pb";
+import {
+  alllowercase,
+  ALLUPPERCASE,
+  lowerCamelCase,
+  UpperCamelCase,
+  snake_case_snake_case,
+  Upper_snake_Case,
+  M2M,
+  M_2M,
+  M2_M,
+  M2M_,
+  m_22M,
+  m42_M,
+  m24M_,
+  M9,
+} from "ts_protoc_gen/test/bazel/proto/naming_styles_pb";
 
 const person = new DeliveryPerson();
 console.log(person);
 
-
-
+console.log(new alllowercase().setTest(1));
+console.log(new ALLUPPERCASE().setTest(1));
+console.log(new lowerCamelCase().setTest(1));
+console.log(new UpperCamelCase().setTest(1));
+console.log(new snake_case_snake_case().setTest(1));
+console.log(new Upper_snake_Case().setTest(1));
+console.log(new M2M().setTest(1));
+console.log(new M_2M().setTest(1));
+console.log(new M2_M().setTest(1));
+console.log(new M2M_().setTest(1));
+console.log(new m_22M().setTest(1));
+console.log(new m42_M().setTest(1));
+console.log(new m24M_().setTest(1));
+console.log(new M9().setTest(1));


### PR DESCRIPTION
Fixes a bug in the bazel rules where names with numbers were not being exported and adds a test.