### PR TITLE
GRPC-Node :: Generate Server Interface from Service Proto

### DIFF
--- a/examples/generated-grpc-node/proto/examplecom/simple_service_grpc_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/simple_service_grpc_pb.d.ts
@@ -18,6 +18,14 @@ interface ISimpleServiceService extends grpc.ServiceDefinition<grpc.UntypedServi
 
 export const SimpleServiceService: ISimpleServiceService;
 
+interface ISimpleServiceServer {
+  doUnary: grpc.handleUnaryCall<proto_examplecom_simple_service_pb.UnaryRequest, proto_othercom_external_child_message_pb.ExternalChildMessage>;
+  doServerStream: grpc.handleUnaryCall<proto_examplecom_simple_service_pb.StreamRequest, proto_othercom_external_child_message_pb.ExternalChildMessage>;
+  doClientStream: grpc.handleUnaryCall<proto_examplecom_simple_service_pb.StreamRequest, google_protobuf_empty_pb.Empty>;
+  doBidiStream: grpc.handleUnaryCall<proto_examplecom_simple_service_pb.StreamRequest, proto_othercom_external_child_message_pb.ExternalChildMessage>;
+  delete: grpc.handleUnaryCall<proto_examplecom_simple_service_pb.UnaryRequest, proto_examplecom_simple_service_pb.UnaryResponse>;
+}
+
 export class SimpleServiceClient extends grpc.Client {
   constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
   doUnary(argument: proto_examplecom_simple_service_pb.UnaryRequest, callback: grpc.requestCallback<proto_othercom_external_child_message_pb.ExternalChildMessage>): grpc.ClientUnaryCall;

--- a/examples/generated-grpc-node/proto/orphan_grpc_pb.d.ts
+++ b/examples/generated-grpc-node/proto/orphan_grpc_pb.d.ts
@@ -13,6 +13,11 @@ interface IOrphanServiceService extends grpc.ServiceDefinition<grpc.UntypedServi
 
 export const OrphanServiceService: IOrphanServiceService;
 
+interface IOrphanServiceServer {
+  doUnary: grpc.handleUnaryCall<proto_orphan_pb.OrphanUnaryRequest, proto_orphan_pb.OrphanMessage>;
+  doStream: grpc.handleUnaryCall<proto_orphan_pb.OrphanStreamRequest, proto_orphan_pb.OrphanMessage>;
+}
+
 export class OrphanServiceClient extends grpc.Client {
   constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
   doUnary(argument: proto_orphan_pb.OrphanUnaryRequest, callback: grpc.requestCallback<proto_orphan_pb.OrphanMessage>): grpc.ClientUnaryCall;

--- a/src/service/grpcnode.ts
+++ b/src/service/grpcnode.ts
@@ -41,10 +41,23 @@ function generateTypeScriptDefinition(fileDescriptor: FileDescriptorProto, expor
       printer.printEmptyLn();
       printService(printer, service);
       printer.printEmptyLn();
+      printServer(printer, service);
+      printer.printEmptyLn();
       printClient(printer, service);
     });
 
   return printer.getOutput();
+}
+
+function printServer(printer: Printer, service: RPCDescriptor) {
+  const serverName = `${service.name}Server`;
+  printer.printLn(`interface I${serverName} {`);
+  service.methods
+      .forEach(method => {
+        const methodType = `grpc.handleUnaryCall<${method.requestType}, ${method.responseType}>`;
+        printer.printIndentedLn(`${method.nameAsCamelCase}: ${methodType};`);
+      });
+  printer.printLn("}");
 }
 
 function printService(printer: Printer, service: RPCDescriptor) {


### PR DESCRIPTION

## Changes
There was a request to add server definitions for NodeJS
Issue: [#220](https://github.com/improbable-eng/ts-protoc-gen/issues/220)
Created a server definition function that will print to file the Server Interface.

## Verification

1. Ran the Generate step in package.json
2. Checked example: orphan_grpc_pb.d.ts in examples/generated-grpc-node/proto
