### PR TITLE
Fix parameter name

### DIFF
--- a/src/ts/fileDescriptorTSD.ts
+++ b/src/ts/fileDescriptorTSD.ts
@@ -31,8 +31,8 @@ export function printFileDescriptorTSD(fileDescriptor: FileDescriptorProto, expo
     }
   });
 
-  fileDescriptor.getMessageTypeList().forEach(enumType => {
-    printer.print(printMessage(fileName, exportMap, enumType, 0, fileDescriptor));
+  fileDescriptor.getMessageTypeList().forEach(messageType => {
+    printer.print(printMessage(fileName, exportMap, messageType, 0, fileDescriptor));
   });
 
   fileDescriptor.getExtensionList().forEach(extension => {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

Changed parameter name from `enumType` to more appropriate `messageType`.

## Verification

Doesn't seem necessary.
