### PR TITLE
Include leading comments from proto file for message and enum types

### DIFF
--- a/examples/generated-grpc-node/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/simplevalue_pb.d.ts
@@ -12,35 +12,59 @@ export class SimpleValue extends jspb.Message {
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
+  /**
+   * Represents a double value.
+   */
   getNumberValue(): number;
   setNumberValue(value: number): void;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
+  /**
+   * Represents a string value.
+   */
   getStringValue(): string;
   setStringValue(value: string): void;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBoolValue(): boolean;
   setBoolValue(value: boolean): void;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
+  /**
+   * Represents a double value.
+   */
   getNumber2Value(): number;
   setNumber2Value(value: number): void;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
+  /**
+   * Represents a string value.
+   */
   getString2Value(): string;
   setString2Value(value: string): void;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBool2Value(): boolean;
   setBool2Value(value: boolean): void;
 
+  /**
+   * The kind of value.
+   */
   getKindCase(): SimpleValue.KindCase;
+  /**
+   * The kind of value.
+   */
   getAnotherCase(): SimpleValue.AnotherCase;
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SimpleValue.AsObject;
@@ -56,11 +80,29 @@ export namespace SimpleValue {
   export type AsObject = {
     firstField: string,
     secondField: number,
+    /**
+     * Represents a double value.
+     */
     numberValue: number,
+    /**
+     * Represents a string value.
+     */
     stringValue: string,
+    /**
+     * Represents a boolean value.
+     */
     boolValue: boolean,
+    /**
+     * Represents a double value.
+     */
     number2Value: number,
+    /**
+     * Represents a string value.
+     */
     string2Value: string,
+    /**
+     * Represents a boolean value.
+     */
     bool2Value: boolean,
   }
 

--- a/examples/generated-grpc-web/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/simplevalue_pb.d.ts
@@ -12,35 +12,59 @@ export class SimpleValue extends jspb.Message {
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
+  /**
+   * Represents a double value.
+   */
   getNumberValue(): number;
   setNumberValue(value: number): void;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
+  /**
+   * Represents a string value.
+   */
   getStringValue(): string;
   setStringValue(value: string): void;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBoolValue(): boolean;
   setBoolValue(value: boolean): void;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
+  /**
+   * Represents a double value.
+   */
   getNumber2Value(): number;
   setNumber2Value(value: number): void;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
+  /**
+   * Represents a string value.
+   */
   getString2Value(): string;
   setString2Value(value: string): void;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBool2Value(): boolean;
   setBool2Value(value: boolean): void;
 
+  /**
+   * The kind of value.
+   */
   getKindCase(): SimpleValue.KindCase;
+  /**
+   * The kind of value.
+   */
   getAnotherCase(): SimpleValue.AnotherCase;
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SimpleValue.AsObject;
@@ -56,11 +80,29 @@ export namespace SimpleValue {
   export type AsObject = {
     firstField: string,
     secondField: number,
+    /**
+     * Represents a double value.
+     */
     numberValue: number,
+    /**
+     * Represents a string value.
+     */
     stringValue: string,
+    /**
+     * Represents a boolean value.
+     */
     boolValue: boolean,
+    /**
+     * Represents a double value.
+     */
     number2Value: number,
+    /**
+     * Represents a string value.
+     */
     string2Value: string,
+    /**
+     * Represents a boolean value.
+     */
     bool2Value: boolean,
   }
 

--- a/examples/generated/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated/proto/examplecom/simplevalue_pb.d.ts
@@ -12,35 +12,59 @@ export class SimpleValue extends jspb.Message {
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
+  /**
+   * Represents a double value.
+   */
   getNumberValue(): number;
   setNumberValue(value: number): void;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
+  /**
+   * Represents a string value.
+   */
   getStringValue(): string;
   setStringValue(value: string): void;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBoolValue(): boolean;
   setBoolValue(value: boolean): void;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
+  /**
+   * Represents a double value.
+   */
   getNumber2Value(): number;
   setNumber2Value(value: number): void;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
+  /**
+   * Represents a string value.
+   */
   getString2Value(): string;
   setString2Value(value: string): void;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
+  /**
+   * Represents a boolean value.
+   */
   getBool2Value(): boolean;
   setBool2Value(value: boolean): void;
 
+  /**
+   * The kind of value.
+   */
   getKindCase(): SimpleValue.KindCase;
+  /**
+   * The kind of value.
+   */
   getAnotherCase(): SimpleValue.AnotherCase;
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SimpleValue.AsObject;
@@ -56,11 +80,29 @@ export namespace SimpleValue {
   export type AsObject = {
     firstField: string,
     secondField: number,
+    /**
+     * Represents a double value.
+     */
     numberValue: number,
+    /**
+     * Represents a string value.
+     */
     stringValue: string,
+    /**
+     * Represents a boolean value.
+     */
     boolValue: boolean,
+    /**
+     * Represents a double value.
+     */
     number2Value: number,
+    /**
+     * Represents a string value.
+     */
     string2Value: string,
+    /**
+     * Represents a boolean value.
+     */
     bool2Value: boolean,
   }
 

--- a/src/ts/CommentsMap.ts
+++ b/src/ts/CommentsMap.ts
@@ -1,0 +1,141 @@
+import {SourceCodeInfo, FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
+
+const VALUE_KEY = "value";
+/**
+ * index the path list to location index mapping to a tree structure
+ * store location index value on node 'value' key
+ * e.g. [4][1][2][0][1]: { value: 15 }
+ */
+interface IndexNode {
+  [k: number]: IndexNode;
+  [VALUE_KEY]?: number;
+}
+
+export class BaseComments {
+  constructor(protected locationList: SourceCodeInfo.Location[], protected indexNode: IndexNode) {}
+
+  printLeadingComments(printLn: (text: string) => void) {
+    const location = this.getLocation();
+    if (!location || !location.hasLeadingComments()) {
+      return;
+    }
+
+    printLn(`/**`);
+    location.getLeadingComments().trim().split("\n").forEach(line => {
+      printLn(` * ${line}`);
+    });
+    printLn(` */`);
+  }
+
+  getLocation(): SourceCodeInfo.Location | undefined {
+    if (!this.indexNode) {
+      return undefined;
+    }
+    return this.locationList[this.indexNode[VALUE_KEY] || -1];
+  }
+}
+
+export class EnumComments extends BaseComments {
+  constructor(locationList: SourceCodeInfo.Location[], indexNode: IndexNode) {
+    super(locationList, indexNode);
+  }
+
+  getValue(index: number): BaseComments {
+    return new BaseComments(
+      this.locationList,
+      this.indexNode[2] && this.indexNode[2][index]
+    );
+  }
+}
+
+
+export class MessageComments extends BaseComments {
+  constructor(locationList: SourceCodeInfo.Location[], indexNode: IndexNode) {
+    super(locationList, indexNode);
+  }
+
+  getField(index: number): BaseComments {
+    return new BaseComments(
+      this.locationList,
+      this.indexNode[2] && this.indexNode[2][index]
+    );
+  }
+
+  getNestType(index: number): MessageComments {
+    return new MessageComments(
+      this.locationList,
+      this.indexNode[3] && this.indexNode[3][index]
+    );
+  }
+
+  getEnumType(index: number): EnumComments {
+    return new EnumComments(
+      this.locationList,
+      this.indexNode[4] && this.indexNode[4][index]
+    );
+  }
+
+  getOneofDecl(index: number): BaseComments {
+    return new BaseComments(
+      this.locationList,
+      this.indexNode[8] && this.indexNode[8][index]
+    );
+  }
+}
+
+export class ServiceComments extends BaseComments {
+  constructor(locationList: SourceCodeInfo.Location[], indexNode: IndexNode) {
+    super(locationList, indexNode);
+  }
+
+  getMethod(index: number): BaseComments {
+    return new BaseComments(
+      this.locationList,
+      this.indexNode[2] && this.indexNode[2][index]
+    );
+  }
+}
+
+
+export class CommentsMap {
+  private locationList: SourceCodeInfo.Location[];
+  private indexedLocations: IndexNode = {};
+
+  constructor(fileDescriptor: FileDescriptorProto) {
+    this.locationList = fileDescriptor.getSourceCodeInfo().getLocationList();
+    // index locations
+    this.locationList.forEach((location, index) => {
+      const pathList = location.getPathList();
+      let node = this.indexedLocations;
+      for (let i = 0; i < pathList.length; i++) {
+        const subIndex = pathList[i];
+        if (!node[subIndex]) {
+          node[subIndex] = {};
+        }
+        node = node[subIndex];
+      }
+      node[VALUE_KEY] = index;
+    });
+  }
+
+  getMessageType(index: number): MessageComments {
+    return new MessageComments(
+      this.locationList,
+      this.indexedLocations[4] && this.indexedLocations[4][index]
+    );
+  }
+
+  getEnumType(index: number): EnumComments {
+    return new EnumComments(
+      this.locationList,
+      this.indexedLocations[5] && this.indexedLocations[5][index]
+    );
+  }
+
+  getService(index: number): ServiceComments {
+    return new ServiceComments(
+      this.locationList,
+      this.indexedLocations[6] && this.indexedLocations[6][index]
+    );
+  }
+}

--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -1,12 +1,16 @@
 import {EnumDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
 import {Printer} from "../Printer";
+import {EnumComments} from "./CommentsMap";
 
-export function printEnum(enumDescriptor: EnumDescriptorProto, indentLevel: number) {
+export function printEnum(enumDescriptor: EnumDescriptorProto, indentLevel: number, comments: EnumComments) {
   const printer = new Printer(indentLevel);
   const enumInterfaceName = `${enumDescriptor.getName()}Map`;
   printer.printEmptyLn();
+  comments.printLeadingComments(text => printer.printLn(text));
   printer.printLn(`export interface ${enumInterfaceName} {`);
-  enumDescriptor.getValueList().forEach(value => {
+  enumDescriptor.getValueList().forEach((value, i) => {
+    const valueComments = comments.getValue(i);
+    valueComments.printLeadingComments(text => printer.printIndentedLn(text));
     printer.printIndentedLn(`${value.getName().toUpperCase()}: ${value.getNumber()};`);
   });
   printer.printLn(`}`);

--- a/src/ts/fileDescriptorTSD.ts
+++ b/src/ts/fileDescriptorTSD.ts
@@ -6,6 +6,7 @@ import {WellKnownTypesMap} from "../WellKnown";
 import {printMessage} from "./message";
 import {printEnum} from "./enum";
 import {printExtension} from "./extensions";
+import {CommentsMap} from "./CommentsMap";
 
 export function printFileDescriptorTSD(fileDescriptor: FileDescriptorProto, exportMap: ExportMap) {
   const fileName = fileDescriptor.getName();
@@ -21,6 +22,8 @@ export function printFileDescriptorTSD(fileDescriptor: FileDescriptorProto, expo
   printer.printEmptyLn();
   printer.printLn(`import * as jspb from "google-protobuf";`);
 
+  const commentsMap = new CommentsMap(fileDescriptor);
+
   fileDescriptor.getDependencyList().forEach((dependency: string) => {
     const pseudoNamespace = filePathToPseudoNamespace(dependency);
     if (dependency in WellKnownTypesMap) {
@@ -31,16 +34,16 @@ export function printFileDescriptorTSD(fileDescriptor: FileDescriptorProto, expo
     }
   });
 
-  fileDescriptor.getMessageTypeList().forEach(enumType => {
-    printer.print(printMessage(fileName, exportMap, enumType, 0, fileDescriptor));
+  fileDescriptor.getMessageTypeList().forEach((messageType, i) => {
+    printer.print(printMessage(fileName, exportMap, messageType, 0, fileDescriptor, commentsMap.getMessageType(i)));
   });
 
   fileDescriptor.getExtensionList().forEach(extension => {
     printer.print(printExtension(fileName, exportMap, extension, 0));
   });
 
-  fileDescriptor.getEnumTypeList().forEach(enumType => {
-    printer.print(printEnum(enumType, 0));
+  fileDescriptor.getEnumTypeList().forEach((enumType, i) => {
+    printer.print(printEnum(enumType, 0, commentsMap.getEnumType(i)));
   });
 
   printer.printEmptyLn();


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Include the proto file leading comments for enum type and its values, message type and its `AsObject` type fields + getter methods


## Changes
* add `ts/CommentsMap` to parse the LocationList
* modify `ts/message`, `ts/enum` to write leading comments
* update generated example
<!-- Enumerate changes you made -->

## Verification
tested with the example proto

<!-- How you tested it? How do you know it works? -->
