### PR TITLE
Add support for proto3 optional presence

### DIFF
--- a/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.d.ts
@@ -10,6 +10,11 @@ export class ParentMessageV3 extends jspb.Message {
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
   setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
 
+  hasOptInternalChildMessage(): boolean;
+  clearOptInternalChildMessage(): void;
+  getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
   setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
@@ -19,6 +24,11 @@ export class ParentMessageV3 extends jspb.Message {
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
   setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+
+  hasOptExternalChildMessage(): boolean;
+  clearOptExternalChildMessage(): void;
+  getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
@@ -38,8 +48,10 @@ export class ParentMessageV3 extends jspb.Message {
 export namespace ParentMessageV3 {
   export type AsObject = {
     internalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
+    optInternalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
     internalChildrenList: Array<ParentMessageV3.InternalChildMessage.AsObject>,
     externalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
+    optExternalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
     externalChildrenList: Array<proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject>,
   }
 

--- a/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.js
+++ b/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.js
@@ -67,7 +67,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.examplecom.ParentMessageV3.repeatedFields_ = [2,4];
+proto.examplecom.ParentMessageV3.repeatedFields_ = [3,6];
 
 
 
@@ -101,9 +101,11 @@ proto.examplecom.ParentMessageV3.prototype.toObject = function(opt_includeInstan
 proto.examplecom.ParentMessageV3.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalChildMessage: (f = msg.getInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
+    optInternalChildMessage: (f = msg.getOptInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
     internalChildrenList: jspb.Message.toObjectList(msg.getInternalChildrenList(),
     proto.examplecom.ParentMessageV3.InternalChildMessage.toObject, includeInstance),
     externalChildMessage: (f = msg.getExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
+    optExternalChildMessage: (f = msg.getOptExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
     externalChildrenList: jspb.Message.toObjectList(msg.getExternalChildrenList(),
     proto_othercom_external_child_message_pb.ExternalChildMessage.toObject, includeInstance)
   };
@@ -150,14 +152,24 @@ proto.examplecom.ParentMessageV3.deserializeBinaryFromReader = function(msg, rea
     case 2:
       var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
       reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
-      msg.addInternalChildren(value);
+      msg.setOptInternalChildMessage(value);
       break;
     case 3:
+      var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
+      reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
+      msg.addInternalChildren(value);
+      break;
+    case 4:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.setExternalChildMessage(value);
       break;
-    case 4:
+    case 5:
+      var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
+      reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
+      msg.setOptExternalChildMessage(value);
+      break;
+    case 6:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.addExternalChildren(value);
@@ -199,10 +211,18 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
   }
+  f = message.getOptInternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
+    );
+  }
   f = message.getInternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      2,
+      3,
       f,
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
@@ -210,7 +230,15 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildMessage();
   if (f != null) {
     writer.writeMessage(
-      3,
+      4,
+      f,
+      proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
+    );
+  }
+  f = message.getOptExternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -218,7 +246,7 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      4,
+      6,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -394,12 +422,49 @@ proto.examplecom.ParentMessageV3.prototype.hasInternalChildMessage = function() 
 
 
 /**
- * repeated InternalChildMessage internal_children = 2;
+ * optional InternalChildMessage opt_internal_child_message = 2;
+ * @return {?proto.examplecom.ParentMessageV3.InternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptInternalChildMessage = function() {
+  return /** @type{?proto.examplecom.ParentMessageV3.InternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+};
+
+
+/**
+ * @param {?proto.examplecom.ParentMessageV3.InternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptInternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptInternalChildMessage = function() {
+  return this.setOptInternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptInternalChildMessage = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * repeated InternalChildMessage internal_children = 3;
  * @return {!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() {
   return /** @type{!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 3));
 };
 
 
@@ -408,7 +473,7 @@ proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 2, value);
+  return jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
 
 
@@ -418,7 +483,7 @@ proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(va
  * @return {!proto.examplecom.ParentMessageV3.InternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addInternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
 };
 
 
@@ -432,12 +497,12 @@ proto.examplecom.ParentMessageV3.prototype.clearInternalChildrenList = function(
 
 
 /**
- * optional othercom.ExternalChildMessage external_child_message = 3;
+ * optional othercom.ExternalChildMessage external_child_message = 4;
  * @return {?proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() {
   return /** @type{?proto.othercom.ExternalChildMessage} */ (
-    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 3));
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
 };
 
 
@@ -446,7 +511,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildMessage = function(value) {
-  return jspb.Message.setWrapperField(this, 3, value);
+  return jspb.Message.setWrapperField(this, 4, value);
 };
 
 
@@ -464,17 +529,54 @@ proto.examplecom.ParentMessageV3.prototype.clearExternalChildMessage = function(
  * @return {boolean}
  */
 proto.examplecom.ParentMessageV3.prototype.hasExternalChildMessage = function() {
-  return jspb.Message.getField(this, 3) != null;
+  return jspb.Message.getField(this, 4) != null;
 };
 
 
 /**
- * repeated othercom.ExternalChildMessage external_children = 4;
+ * optional othercom.ExternalChildMessage opt_external_child_message = 5;
+ * @return {?proto.othercom.ExternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptExternalChildMessage = function() {
+  return /** @type{?proto.othercom.ExternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 5));
+};
+
+
+/**
+ * @param {?proto.othercom.ExternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptExternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptExternalChildMessage = function() {
+  return this.setOptExternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptExternalChildMessage = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * repeated othercom.ExternalChildMessage external_children = 6;
  * @return {!Array<!proto.othercom.ExternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() {
   return /** @type{!Array<!proto.othercom.ExternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
+    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 6));
 };
 
 
@@ -483,7 +585,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 4, value);
+  return jspb.Message.setRepeatedWrapperField(this, 6, value);
 };
 
 
@@ -493,7 +595,7 @@ proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(va
  * @return {!proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addExternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.othercom.ExternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 6, opt_value, proto.othercom.ExternalChildMessage, opt_index);
 };
 
 

--- a/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -54,6 +54,88 @@ export class PrimitiveMessageV3 extends jspb.Message {
   getMyNumber(): number;
   setMyNumber(value: number): void;
 
+  hasOptDouble(): boolean;
+  clearOptDouble(): void;
+  getOptDouble(): number;
+  setOptDouble(value: number): void;
+
+  hasOptFloat(): boolean;
+  clearOptFloat(): void;
+  getOptFloat(): number;
+  setOptFloat(value: number): void;
+
+  hasOptInt32(): boolean;
+  clearOptInt32(): void;
+  getOptInt32(): number;
+  setOptInt32(value: number): void;
+
+  hasOptInt64(): boolean;
+  clearOptInt64(): void;
+  getOptInt64(): number;
+  setOptInt64(value: number): void;
+
+  hasOptUint32(): boolean;
+  clearOptUint32(): void;
+  getOptUint32(): number;
+  setOptUint32(value: number): void;
+
+  hasOptUint64(): boolean;
+  clearOptUint64(): void;
+  getOptUint64(): number;
+  setOptUint64(value: number): void;
+
+  hasOptSint32(): boolean;
+  clearOptSint32(): void;
+  getOptSint32(): number;
+  setOptSint32(value: number): void;
+
+  hasOptSint64(): boolean;
+  clearOptSint64(): void;
+  getOptSint64(): number;
+  setOptSint64(value: number): void;
+
+  hasOptFixed32(): boolean;
+  clearOptFixed32(): void;
+  getOptFixed32(): number;
+  setOptFixed32(value: number): void;
+
+  hasOptFixed64(): boolean;
+  clearOptFixed64(): void;
+  getOptFixed64(): number;
+  setOptFixed64(value: number): void;
+
+  hasOptSfixed32(): boolean;
+  clearOptSfixed32(): void;
+  getOptSfixed32(): number;
+  setOptSfixed32(value: number): void;
+
+  hasOptSfixed64(): boolean;
+  clearOptSfixed64(): void;
+  getOptSfixed64(): number;
+  setOptSfixed64(value: number): void;
+
+  hasOptBool(): boolean;
+  clearOptBool(): void;
+  getOptBool(): boolean;
+  setOptBool(value: boolean): void;
+
+  hasOptString(): boolean;
+  clearOptString(): void;
+  getOptString(): string;
+  setOptString(value: string): void;
+
+  hasOptBytes(): boolean;
+  clearOptBytes(): void;
+  getOptBytes(): Uint8Array | string;
+  getOptBytes_asU8(): Uint8Array;
+  getOptBytes_asB64(): string;
+  setOptBytes(value: Uint8Array | string): void;
+
+  hasOptNumber(): boolean;
+  clearOptNumber(): void;
+  getOptNumber(): number;
+  setOptNumber(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV3): PrimitiveMessageV3.AsObject;
@@ -82,6 +164,22 @@ export namespace PrimitiveMessageV3 {
     myString: string,
     myBytes: Uint8Array | string,
     myNumber: number,
+    optDouble: number,
+    optFloat: number,
+    optInt32: number,
+    optInt64: number,
+    optUint32: number,
+    optUint64: number,
+    optSint32: number,
+    optSint64: number,
+    optFixed32: number,
+    optFixed64: number,
+    optSfixed32: number,
+    optSfixed64: number,
+    optBool: boolean,
+    optString: string,
+    optBytes: Uint8Array | string,
+    optNumber: number,
   }
 }
 

--- a/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.js
+++ b/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.js
@@ -84,7 +84,23 @@ proto.examplecom.PrimitiveMessageV3.toObject = function(includeInstance, msg) {
     myBool: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
     myString: jspb.Message.getFieldWithDefault(msg, 14, ""),
     myBytes: msg.getMyBytes_asB64(),
-    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0)
+    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0),
+    optDouble: jspb.Message.getFloatingPointFieldWithDefault(msg, 17, 0.0),
+    optFloat: jspb.Message.getFloatingPointFieldWithDefault(msg, 18, 0.0),
+    optInt32: jspb.Message.getFieldWithDefault(msg, 19, 0),
+    optInt64: jspb.Message.getFieldWithDefault(msg, 20, 0),
+    optUint32: jspb.Message.getFieldWithDefault(msg, 21, 0),
+    optUint64: jspb.Message.getFieldWithDefault(msg, 22, 0),
+    optSint32: jspb.Message.getFieldWithDefault(msg, 23, 0),
+    optSint64: jspb.Message.getFieldWithDefault(msg, 24, 0),
+    optFixed32: jspb.Message.getFieldWithDefault(msg, 25, 0),
+    optFixed64: jspb.Message.getFieldWithDefault(msg, 26, 0),
+    optSfixed32: jspb.Message.getFieldWithDefault(msg, 27, 0),
+    optSfixed64: jspb.Message.getFieldWithDefault(msg, 28, 0),
+    optBool: jspb.Message.getBooleanFieldWithDefault(msg, 29, false),
+    optString: jspb.Message.getFieldWithDefault(msg, 30, ""),
+    optBytes: msg.getOptBytes_asB64(),
+    optNumber: jspb.Message.getFieldWithDefault(msg, 32, 0)
   };
 
   if (includeInstance) {
@@ -184,6 +200,70 @@ proto.examplecom.PrimitiveMessageV3.deserializeBinaryFromReader = function(msg, 
     case 16:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setMyNumber(value);
+      break;
+    case 17:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setOptDouble(value);
+      break;
+    case 18:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setOptFloat(value);
+      break;
+    case 19:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptInt32(value);
+      break;
+    case 20:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setOptInt64(value);
+      break;
+    case 21:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setOptUint32(value);
+      break;
+    case 22:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOptUint64(value);
+      break;
+    case 23:
+      var value = /** @type {number} */ (reader.readSint32());
+      msg.setOptSint32(value);
+      break;
+    case 24:
+      var value = /** @type {number} */ (reader.readSint64());
+      msg.setOptSint64(value);
+      break;
+    case 25:
+      var value = /** @type {number} */ (reader.readFixed32());
+      msg.setOptFixed32(value);
+      break;
+    case 26:
+      var value = /** @type {number} */ (reader.readFixed64());
+      msg.setOptFixed64(value);
+      break;
+    case 27:
+      var value = /** @type {number} */ (reader.readSfixed32());
+      msg.setOptSfixed32(value);
+      break;
+    case 28:
+      var value = /** @type {number} */ (reader.readSfixed64());
+      msg.setOptSfixed64(value);
+      break;
+    case 29:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOptBool(value);
+      break;
+    case 30:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOptString(value);
+      break;
+    case 31:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setOptBytes(value);
+      break;
+    case 32:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptNumber(value);
       break;
     default:
       reader.skipField();
@@ -323,6 +403,118 @@ proto.examplecom.PrimitiveMessageV3.serializeBinaryToWriter = function(message, 
   if (f !== 0) {
     writer.writeInt32(
       16,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 17));
+  if (f != null) {
+    writer.writeDouble(
+      17,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 18));
+  if (f != null) {
+    writer.writeFloat(
+      18,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 19));
+  if (f != null) {
+    writer.writeInt32(
+      19,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 20));
+  if (f != null) {
+    writer.writeInt64(
+      20,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 21));
+  if (f != null) {
+    writer.writeUint32(
+      21,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 22));
+  if (f != null) {
+    writer.writeUint64(
+      22,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 23));
+  if (f != null) {
+    writer.writeSint32(
+      23,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 24));
+  if (f != null) {
+    writer.writeSint64(
+      24,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 25));
+  if (f != null) {
+    writer.writeFixed32(
+      25,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 26));
+  if (f != null) {
+    writer.writeFixed64(
+      26,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 27));
+  if (f != null) {
+    writer.writeSfixed32(
+      27,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 28));
+  if (f != null) {
+    writer.writeSfixed64(
+      28,
+      f
+    );
+  }
+  f = /** @type {boolean} */ (jspb.Message.getField(message, 29));
+  if (f != null) {
+    writer.writeBool(
+      29,
+      f
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 30));
+  if (f != null) {
+    writer.writeString(
+      30,
+      f
+    );
+  }
+  f = /** @type {!(string|Uint8Array)} */ (jspb.Message.getField(message, 31));
+  if (f != null) {
+    writer.writeBytes(
+      31,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 32));
+  if (f != null) {
+    writer.writeInt32(
+      32,
       f
     );
   }
@@ -638,6 +830,606 @@ proto.examplecom.PrimitiveMessageV3.prototype.getMyNumber = function() {
  */
 proto.examplecom.PrimitiveMessageV3.prototype.setMyNumber = function(value) {
   return jspb.Message.setProto3IntField(this, 16, value);
+};
+
+
+/**
+ * optional double opt_double = 17;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptDouble = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 17, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptDouble = function(value) {
+  return jspb.Message.setField(this, 17, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptDouble = function() {
+  return jspb.Message.setField(this, 17, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptDouble = function() {
+  return jspb.Message.getField(this, 17) != null;
+};
+
+
+/**
+ * optional float opt_float = 18;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFloat = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 18, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFloat = function(value) {
+  return jspb.Message.setField(this, 18, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFloat = function() {
+  return jspb.Message.setField(this, 18, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFloat = function() {
+  return jspb.Message.getField(this, 18) != null;
+};
+
+
+/**
+ * optional int32 opt_int32 = 19;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 19, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt32 = function(value) {
+  return jspb.Message.setField(this, 19, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt32 = function() {
+  return jspb.Message.setField(this, 19, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt32 = function() {
+  return jspb.Message.getField(this, 19) != null;
+};
+
+
+/**
+ * optional int64 opt_int64 = 20;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 20, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt64 = function(value) {
+  return jspb.Message.setField(this, 20, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt64 = function() {
+  return jspb.Message.setField(this, 20, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt64 = function() {
+  return jspb.Message.getField(this, 20) != null;
+};
+
+
+/**
+ * optional uint32 opt_uint32 = 21;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 21, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint32 = function(value) {
+  return jspb.Message.setField(this, 21, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint32 = function() {
+  return jspb.Message.setField(this, 21, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint32 = function() {
+  return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional uint64 opt_uint64 = 22;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 22, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint64 = function(value) {
+  return jspb.Message.setField(this, 22, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint64 = function() {
+  return jspb.Message.setField(this, 22, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint64 = function() {
+  return jspb.Message.getField(this, 22) != null;
+};
+
+
+/**
+ * optional sint32 opt_sint32 = 23;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 23, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint32 = function(value) {
+  return jspb.Message.setField(this, 23, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint32 = function() {
+  return jspb.Message.setField(this, 23, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint32 = function() {
+  return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional sint64 opt_sint64 = 24;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 24, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint64 = function(value) {
+  return jspb.Message.setField(this, 24, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint64 = function() {
+  return jspb.Message.setField(this, 24, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint64 = function() {
+  return jspb.Message.getField(this, 24) != null;
+};
+
+
+/**
+ * optional fixed32 opt_fixed32 = 25;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 25, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed32 = function(value) {
+  return jspb.Message.setField(this, 25, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed32 = function() {
+  return jspb.Message.setField(this, 25, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed32 = function() {
+  return jspb.Message.getField(this, 25) != null;
+};
+
+
+/**
+ * optional fixed64 opt_fixed64 = 26;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 26, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed64 = function(value) {
+  return jspb.Message.setField(this, 26, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed64 = function() {
+  return jspb.Message.setField(this, 26, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed64 = function() {
+  return jspb.Message.getField(this, 26) != null;
+};
+
+
+/**
+ * optional sfixed32 opt_sfixed32 = 27;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 27, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed32 = function(value) {
+  return jspb.Message.setField(this, 27, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed32 = function() {
+  return jspb.Message.setField(this, 27, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed32 = function() {
+  return jspb.Message.getField(this, 27) != null;
+};
+
+
+/**
+ * optional sfixed64 opt_sfixed64 = 28;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 28, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed64 = function(value) {
+  return jspb.Message.setField(this, 28, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed64 = function() {
+  return jspb.Message.setField(this, 28, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed64 = function() {
+  return jspb.Message.getField(this, 28) != null;
+};
+
+
+/**
+ * optional bool opt_bool = 29;
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBool = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 29, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBool = function(value) {
+  return jspb.Message.setField(this, 29, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBool = function() {
+  return jspb.Message.setField(this, 29, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBool = function() {
+  return jspb.Message.getField(this, 29) != null;
+};
+
+
+/**
+ * optional string opt_string = 30;
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptString = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 30, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptString = function(value) {
+  return jspb.Message.setField(this, 30, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptString = function() {
+  return jspb.Message.setField(this, 30, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptString = function() {
+  return jspb.Message.getField(this, 30) != null;
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * @return {!(string|Uint8Array)}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 31, ""));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getOptBytes()));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {!Uint8Array}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getOptBytes()));
+};
+
+
+/**
+ * @param {!(string|Uint8Array)} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBytes = function(value) {
+  return jspb.Message.setField(this, 31, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBytes = function() {
+  return jspb.Message.setField(this, 31, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBytes = function() {
+  return jspb.Message.getField(this, 31) != null;
+};
+
+
+/**
+ * optional int32 opt_NUMBER = 32;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 32, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptNumber = function(value) {
+  return jspb.Message.setField(this, 32, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptNumber = function() {
+  return jspb.Message.setField(this, 32, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptNumber = function() {
+  return jspb.Message.getField(this, 32) != null;
 };
 
 

--- a/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.d.ts
@@ -10,6 +10,11 @@ export class ParentMessageV3 extends jspb.Message {
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
   setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
 
+  hasOptInternalChildMessage(): boolean;
+  clearOptInternalChildMessage(): void;
+  getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
   setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
@@ -19,6 +24,11 @@ export class ParentMessageV3 extends jspb.Message {
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
   setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+
+  hasOptExternalChildMessage(): boolean;
+  clearOptExternalChildMessage(): void;
+  getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
@@ -38,8 +48,10 @@ export class ParentMessageV3 extends jspb.Message {
 export namespace ParentMessageV3 {
   export type AsObject = {
     internalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
+    optInternalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
     internalChildrenList: Array<ParentMessageV3.InternalChildMessage.AsObject>,
     externalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
+    optExternalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
     externalChildrenList: Array<proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject>,
   }
 

--- a/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.js
+++ b/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.js
@@ -67,7 +67,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.examplecom.ParentMessageV3.repeatedFields_ = [2,4];
+proto.examplecom.ParentMessageV3.repeatedFields_ = [3,6];
 
 
 
@@ -101,9 +101,11 @@ proto.examplecom.ParentMessageV3.prototype.toObject = function(opt_includeInstan
 proto.examplecom.ParentMessageV3.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalChildMessage: (f = msg.getInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
+    optInternalChildMessage: (f = msg.getOptInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
     internalChildrenList: jspb.Message.toObjectList(msg.getInternalChildrenList(),
     proto.examplecom.ParentMessageV3.InternalChildMessage.toObject, includeInstance),
     externalChildMessage: (f = msg.getExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
+    optExternalChildMessage: (f = msg.getOptExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
     externalChildrenList: jspb.Message.toObjectList(msg.getExternalChildrenList(),
     proto_othercom_external_child_message_pb.ExternalChildMessage.toObject, includeInstance)
   };
@@ -150,14 +152,24 @@ proto.examplecom.ParentMessageV3.deserializeBinaryFromReader = function(msg, rea
     case 2:
       var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
       reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
-      msg.addInternalChildren(value);
+      msg.setOptInternalChildMessage(value);
       break;
     case 3:
+      var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
+      reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
+      msg.addInternalChildren(value);
+      break;
+    case 4:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.setExternalChildMessage(value);
       break;
-    case 4:
+    case 5:
+      var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
+      reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
+      msg.setOptExternalChildMessage(value);
+      break;
+    case 6:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.addExternalChildren(value);
@@ -199,10 +211,18 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
   }
+  f = message.getOptInternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
+    );
+  }
   f = message.getInternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      2,
+      3,
       f,
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
@@ -210,7 +230,15 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildMessage();
   if (f != null) {
     writer.writeMessage(
-      3,
+      4,
+      f,
+      proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
+    );
+  }
+  f = message.getOptExternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -218,7 +246,7 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      4,
+      6,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -394,12 +422,49 @@ proto.examplecom.ParentMessageV3.prototype.hasInternalChildMessage = function() 
 
 
 /**
- * repeated InternalChildMessage internal_children = 2;
+ * optional InternalChildMessage opt_internal_child_message = 2;
+ * @return {?proto.examplecom.ParentMessageV3.InternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptInternalChildMessage = function() {
+  return /** @type{?proto.examplecom.ParentMessageV3.InternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+};
+
+
+/**
+ * @param {?proto.examplecom.ParentMessageV3.InternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptInternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptInternalChildMessage = function() {
+  return this.setOptInternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptInternalChildMessage = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * repeated InternalChildMessage internal_children = 3;
  * @return {!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() {
   return /** @type{!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 3));
 };
 
 
@@ -408,7 +473,7 @@ proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 2, value);
+  return jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
 
 
@@ -418,7 +483,7 @@ proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(va
  * @return {!proto.examplecom.ParentMessageV3.InternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addInternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
 };
 
 
@@ -432,12 +497,12 @@ proto.examplecom.ParentMessageV3.prototype.clearInternalChildrenList = function(
 
 
 /**
- * optional othercom.ExternalChildMessage external_child_message = 3;
+ * optional othercom.ExternalChildMessage external_child_message = 4;
  * @return {?proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() {
   return /** @type{?proto.othercom.ExternalChildMessage} */ (
-    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 3));
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
 };
 
 
@@ -446,7 +511,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildMessage = function(value) {
-  return jspb.Message.setWrapperField(this, 3, value);
+  return jspb.Message.setWrapperField(this, 4, value);
 };
 
 
@@ -464,17 +529,54 @@ proto.examplecom.ParentMessageV3.prototype.clearExternalChildMessage = function(
  * @return {boolean}
  */
 proto.examplecom.ParentMessageV3.prototype.hasExternalChildMessage = function() {
-  return jspb.Message.getField(this, 3) != null;
+  return jspb.Message.getField(this, 4) != null;
 };
 
 
 /**
- * repeated othercom.ExternalChildMessage external_children = 4;
+ * optional othercom.ExternalChildMessage opt_external_child_message = 5;
+ * @return {?proto.othercom.ExternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptExternalChildMessage = function() {
+  return /** @type{?proto.othercom.ExternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 5));
+};
+
+
+/**
+ * @param {?proto.othercom.ExternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptExternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptExternalChildMessage = function() {
+  return this.setOptExternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptExternalChildMessage = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * repeated othercom.ExternalChildMessage external_children = 6;
  * @return {!Array<!proto.othercom.ExternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() {
   return /** @type{!Array<!proto.othercom.ExternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
+    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 6));
 };
 
 
@@ -483,7 +585,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 4, value);
+  return jspb.Message.setRepeatedWrapperField(this, 6, value);
 };
 
 
@@ -493,7 +595,7 @@ proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(va
  * @return {!proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addExternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.othercom.ExternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 6, opt_value, proto.othercom.ExternalChildMessage, opt_index);
 };
 
 

--- a/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -54,6 +54,88 @@ export class PrimitiveMessageV3 extends jspb.Message {
   getMyNumber(): number;
   setMyNumber(value: number): void;
 
+  hasOptDouble(): boolean;
+  clearOptDouble(): void;
+  getOptDouble(): number;
+  setOptDouble(value: number): void;
+
+  hasOptFloat(): boolean;
+  clearOptFloat(): void;
+  getOptFloat(): number;
+  setOptFloat(value: number): void;
+
+  hasOptInt32(): boolean;
+  clearOptInt32(): void;
+  getOptInt32(): number;
+  setOptInt32(value: number): void;
+
+  hasOptInt64(): boolean;
+  clearOptInt64(): void;
+  getOptInt64(): number;
+  setOptInt64(value: number): void;
+
+  hasOptUint32(): boolean;
+  clearOptUint32(): void;
+  getOptUint32(): number;
+  setOptUint32(value: number): void;
+
+  hasOptUint64(): boolean;
+  clearOptUint64(): void;
+  getOptUint64(): number;
+  setOptUint64(value: number): void;
+
+  hasOptSint32(): boolean;
+  clearOptSint32(): void;
+  getOptSint32(): number;
+  setOptSint32(value: number): void;
+
+  hasOptSint64(): boolean;
+  clearOptSint64(): void;
+  getOptSint64(): number;
+  setOptSint64(value: number): void;
+
+  hasOptFixed32(): boolean;
+  clearOptFixed32(): void;
+  getOptFixed32(): number;
+  setOptFixed32(value: number): void;
+
+  hasOptFixed64(): boolean;
+  clearOptFixed64(): void;
+  getOptFixed64(): number;
+  setOptFixed64(value: number): void;
+
+  hasOptSfixed32(): boolean;
+  clearOptSfixed32(): void;
+  getOptSfixed32(): number;
+  setOptSfixed32(value: number): void;
+
+  hasOptSfixed64(): boolean;
+  clearOptSfixed64(): void;
+  getOptSfixed64(): number;
+  setOptSfixed64(value: number): void;
+
+  hasOptBool(): boolean;
+  clearOptBool(): void;
+  getOptBool(): boolean;
+  setOptBool(value: boolean): void;
+
+  hasOptString(): boolean;
+  clearOptString(): void;
+  getOptString(): string;
+  setOptString(value: string): void;
+
+  hasOptBytes(): boolean;
+  clearOptBytes(): void;
+  getOptBytes(): Uint8Array | string;
+  getOptBytes_asU8(): Uint8Array;
+  getOptBytes_asB64(): string;
+  setOptBytes(value: Uint8Array | string): void;
+
+  hasOptNumber(): boolean;
+  clearOptNumber(): void;
+  getOptNumber(): number;
+  setOptNumber(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV3): PrimitiveMessageV3.AsObject;
@@ -82,6 +164,22 @@ export namespace PrimitiveMessageV3 {
     myString: string,
     myBytes: Uint8Array | string,
     myNumber: number,
+    optDouble: number,
+    optFloat: number,
+    optInt32: number,
+    optInt64: number,
+    optUint32: number,
+    optUint64: number,
+    optSint32: number,
+    optSint64: number,
+    optFixed32: number,
+    optFixed64: number,
+    optSfixed32: number,
+    optSfixed64: number,
+    optBool: boolean,
+    optString: string,
+    optBytes: Uint8Array | string,
+    optNumber: number,
   }
 }
 

--- a/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.js
+++ b/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.js
@@ -84,7 +84,23 @@ proto.examplecom.PrimitiveMessageV3.toObject = function(includeInstance, msg) {
     myBool: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
     myString: jspb.Message.getFieldWithDefault(msg, 14, ""),
     myBytes: msg.getMyBytes_asB64(),
-    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0)
+    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0),
+    optDouble: jspb.Message.getFloatingPointFieldWithDefault(msg, 17, 0.0),
+    optFloat: jspb.Message.getFloatingPointFieldWithDefault(msg, 18, 0.0),
+    optInt32: jspb.Message.getFieldWithDefault(msg, 19, 0),
+    optInt64: jspb.Message.getFieldWithDefault(msg, 20, 0),
+    optUint32: jspb.Message.getFieldWithDefault(msg, 21, 0),
+    optUint64: jspb.Message.getFieldWithDefault(msg, 22, 0),
+    optSint32: jspb.Message.getFieldWithDefault(msg, 23, 0),
+    optSint64: jspb.Message.getFieldWithDefault(msg, 24, 0),
+    optFixed32: jspb.Message.getFieldWithDefault(msg, 25, 0),
+    optFixed64: jspb.Message.getFieldWithDefault(msg, 26, 0),
+    optSfixed32: jspb.Message.getFieldWithDefault(msg, 27, 0),
+    optSfixed64: jspb.Message.getFieldWithDefault(msg, 28, 0),
+    optBool: jspb.Message.getBooleanFieldWithDefault(msg, 29, false),
+    optString: jspb.Message.getFieldWithDefault(msg, 30, ""),
+    optBytes: msg.getOptBytes_asB64(),
+    optNumber: jspb.Message.getFieldWithDefault(msg, 32, 0)
   };
 
   if (includeInstance) {
@@ -184,6 +200,70 @@ proto.examplecom.PrimitiveMessageV3.deserializeBinaryFromReader = function(msg, 
     case 16:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setMyNumber(value);
+      break;
+    case 17:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setOptDouble(value);
+      break;
+    case 18:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setOptFloat(value);
+      break;
+    case 19:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptInt32(value);
+      break;
+    case 20:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setOptInt64(value);
+      break;
+    case 21:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setOptUint32(value);
+      break;
+    case 22:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOptUint64(value);
+      break;
+    case 23:
+      var value = /** @type {number} */ (reader.readSint32());
+      msg.setOptSint32(value);
+      break;
+    case 24:
+      var value = /** @type {number} */ (reader.readSint64());
+      msg.setOptSint64(value);
+      break;
+    case 25:
+      var value = /** @type {number} */ (reader.readFixed32());
+      msg.setOptFixed32(value);
+      break;
+    case 26:
+      var value = /** @type {number} */ (reader.readFixed64());
+      msg.setOptFixed64(value);
+      break;
+    case 27:
+      var value = /** @type {number} */ (reader.readSfixed32());
+      msg.setOptSfixed32(value);
+      break;
+    case 28:
+      var value = /** @type {number} */ (reader.readSfixed64());
+      msg.setOptSfixed64(value);
+      break;
+    case 29:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOptBool(value);
+      break;
+    case 30:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOptString(value);
+      break;
+    case 31:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setOptBytes(value);
+      break;
+    case 32:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptNumber(value);
       break;
     default:
       reader.skipField();
@@ -323,6 +403,118 @@ proto.examplecom.PrimitiveMessageV3.serializeBinaryToWriter = function(message, 
   if (f !== 0) {
     writer.writeInt32(
       16,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 17));
+  if (f != null) {
+    writer.writeDouble(
+      17,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 18));
+  if (f != null) {
+    writer.writeFloat(
+      18,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 19));
+  if (f != null) {
+    writer.writeInt32(
+      19,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 20));
+  if (f != null) {
+    writer.writeInt64(
+      20,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 21));
+  if (f != null) {
+    writer.writeUint32(
+      21,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 22));
+  if (f != null) {
+    writer.writeUint64(
+      22,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 23));
+  if (f != null) {
+    writer.writeSint32(
+      23,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 24));
+  if (f != null) {
+    writer.writeSint64(
+      24,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 25));
+  if (f != null) {
+    writer.writeFixed32(
+      25,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 26));
+  if (f != null) {
+    writer.writeFixed64(
+      26,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 27));
+  if (f != null) {
+    writer.writeSfixed32(
+      27,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 28));
+  if (f != null) {
+    writer.writeSfixed64(
+      28,
+      f
+    );
+  }
+  f = /** @type {boolean} */ (jspb.Message.getField(message, 29));
+  if (f != null) {
+    writer.writeBool(
+      29,
+      f
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 30));
+  if (f != null) {
+    writer.writeString(
+      30,
+      f
+    );
+  }
+  f = /** @type {!(string|Uint8Array)} */ (jspb.Message.getField(message, 31));
+  if (f != null) {
+    writer.writeBytes(
+      31,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 32));
+  if (f != null) {
+    writer.writeInt32(
+      32,
       f
     );
   }
@@ -638,6 +830,606 @@ proto.examplecom.PrimitiveMessageV3.prototype.getMyNumber = function() {
  */
 proto.examplecom.PrimitiveMessageV3.prototype.setMyNumber = function(value) {
   return jspb.Message.setProto3IntField(this, 16, value);
+};
+
+
+/**
+ * optional double opt_double = 17;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptDouble = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 17, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptDouble = function(value) {
+  return jspb.Message.setField(this, 17, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptDouble = function() {
+  return jspb.Message.setField(this, 17, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptDouble = function() {
+  return jspb.Message.getField(this, 17) != null;
+};
+
+
+/**
+ * optional float opt_float = 18;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFloat = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 18, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFloat = function(value) {
+  return jspb.Message.setField(this, 18, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFloat = function() {
+  return jspb.Message.setField(this, 18, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFloat = function() {
+  return jspb.Message.getField(this, 18) != null;
+};
+
+
+/**
+ * optional int32 opt_int32 = 19;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 19, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt32 = function(value) {
+  return jspb.Message.setField(this, 19, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt32 = function() {
+  return jspb.Message.setField(this, 19, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt32 = function() {
+  return jspb.Message.getField(this, 19) != null;
+};
+
+
+/**
+ * optional int64 opt_int64 = 20;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 20, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt64 = function(value) {
+  return jspb.Message.setField(this, 20, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt64 = function() {
+  return jspb.Message.setField(this, 20, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt64 = function() {
+  return jspb.Message.getField(this, 20) != null;
+};
+
+
+/**
+ * optional uint32 opt_uint32 = 21;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 21, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint32 = function(value) {
+  return jspb.Message.setField(this, 21, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint32 = function() {
+  return jspb.Message.setField(this, 21, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint32 = function() {
+  return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional uint64 opt_uint64 = 22;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 22, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint64 = function(value) {
+  return jspb.Message.setField(this, 22, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint64 = function() {
+  return jspb.Message.setField(this, 22, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint64 = function() {
+  return jspb.Message.getField(this, 22) != null;
+};
+
+
+/**
+ * optional sint32 opt_sint32 = 23;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 23, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint32 = function(value) {
+  return jspb.Message.setField(this, 23, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint32 = function() {
+  return jspb.Message.setField(this, 23, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint32 = function() {
+  return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional sint64 opt_sint64 = 24;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 24, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint64 = function(value) {
+  return jspb.Message.setField(this, 24, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint64 = function() {
+  return jspb.Message.setField(this, 24, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint64 = function() {
+  return jspb.Message.getField(this, 24) != null;
+};
+
+
+/**
+ * optional fixed32 opt_fixed32 = 25;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 25, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed32 = function(value) {
+  return jspb.Message.setField(this, 25, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed32 = function() {
+  return jspb.Message.setField(this, 25, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed32 = function() {
+  return jspb.Message.getField(this, 25) != null;
+};
+
+
+/**
+ * optional fixed64 opt_fixed64 = 26;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 26, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed64 = function(value) {
+  return jspb.Message.setField(this, 26, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed64 = function() {
+  return jspb.Message.setField(this, 26, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed64 = function() {
+  return jspb.Message.getField(this, 26) != null;
+};
+
+
+/**
+ * optional sfixed32 opt_sfixed32 = 27;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 27, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed32 = function(value) {
+  return jspb.Message.setField(this, 27, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed32 = function() {
+  return jspb.Message.setField(this, 27, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed32 = function() {
+  return jspb.Message.getField(this, 27) != null;
+};
+
+
+/**
+ * optional sfixed64 opt_sfixed64 = 28;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 28, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed64 = function(value) {
+  return jspb.Message.setField(this, 28, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed64 = function() {
+  return jspb.Message.setField(this, 28, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed64 = function() {
+  return jspb.Message.getField(this, 28) != null;
+};
+
+
+/**
+ * optional bool opt_bool = 29;
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBool = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 29, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBool = function(value) {
+  return jspb.Message.setField(this, 29, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBool = function() {
+  return jspb.Message.setField(this, 29, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBool = function() {
+  return jspb.Message.getField(this, 29) != null;
+};
+
+
+/**
+ * optional string opt_string = 30;
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptString = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 30, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptString = function(value) {
+  return jspb.Message.setField(this, 30, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptString = function() {
+  return jspb.Message.setField(this, 30, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptString = function() {
+  return jspb.Message.getField(this, 30) != null;
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * @return {!(string|Uint8Array)}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 31, ""));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getOptBytes()));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {!Uint8Array}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getOptBytes()));
+};
+
+
+/**
+ * @param {!(string|Uint8Array)} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBytes = function(value) {
+  return jspb.Message.setField(this, 31, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBytes = function() {
+  return jspb.Message.setField(this, 31, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBytes = function() {
+  return jspb.Message.getField(this, 31) != null;
+};
+
+
+/**
+ * optional int32 opt_NUMBER = 32;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 32, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptNumber = function(value) {
+  return jspb.Message.setField(this, 32, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptNumber = function() {
+  return jspb.Message.setField(this, 32, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptNumber = function() {
+  return jspb.Message.getField(this, 32) != null;
 };
 
 

--- a/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.d.ts
@@ -10,6 +10,11 @@ export class ParentMessageV3 extends jspb.Message {
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
   setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
 
+  hasOptInternalChildMessage(): boolean;
+  clearOptInternalChildMessage(): void;
+  getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
   setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
@@ -19,6 +24,11 @@ export class ParentMessageV3 extends jspb.Message {
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
   setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+
+  hasOptExternalChildMessage(): boolean;
+  clearOptExternalChildMessage(): void;
+  getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
@@ -38,8 +48,10 @@ export class ParentMessageV3 extends jspb.Message {
 export namespace ParentMessageV3 {
   export type AsObject = {
     internalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
+    optInternalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
     internalChildrenList: Array<ParentMessageV3.InternalChildMessage.AsObject>,
     externalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
+    optExternalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
     externalChildrenList: Array<proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject>,
   }
 

--- a/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.js
+++ b/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.js
@@ -67,7 +67,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.examplecom.ParentMessageV3.repeatedFields_ = [2,4];
+proto.examplecom.ParentMessageV3.repeatedFields_ = [3,6];
 
 
 
@@ -101,9 +101,11 @@ proto.examplecom.ParentMessageV3.prototype.toObject = function(opt_includeInstan
 proto.examplecom.ParentMessageV3.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalChildMessage: (f = msg.getInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
+    optInternalChildMessage: (f = msg.getOptInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
     internalChildrenList: jspb.Message.toObjectList(msg.getInternalChildrenList(),
     proto.examplecom.ParentMessageV3.InternalChildMessage.toObject, includeInstance),
     externalChildMessage: (f = msg.getExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
+    optExternalChildMessage: (f = msg.getOptExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
     externalChildrenList: jspb.Message.toObjectList(msg.getExternalChildrenList(),
     proto_othercom_external_child_message_pb.ExternalChildMessage.toObject, includeInstance)
   };
@@ -150,14 +152,24 @@ proto.examplecom.ParentMessageV3.deserializeBinaryFromReader = function(msg, rea
     case 2:
       var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
       reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
-      msg.addInternalChildren(value);
+      msg.setOptInternalChildMessage(value);
       break;
     case 3:
+      var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
+      reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
+      msg.addInternalChildren(value);
+      break;
+    case 4:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.setExternalChildMessage(value);
       break;
-    case 4:
+    case 5:
+      var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
+      reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
+      msg.setOptExternalChildMessage(value);
+      break;
+    case 6:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.addExternalChildren(value);
@@ -199,10 +211,18 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
   }
+  f = message.getOptInternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
+    );
+  }
   f = message.getInternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      2,
+      3,
       f,
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
@@ -210,7 +230,15 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildMessage();
   if (f != null) {
     writer.writeMessage(
-      3,
+      4,
+      f,
+      proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
+    );
+  }
+  f = message.getOptExternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -218,7 +246,7 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      4,
+      6,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -394,12 +422,49 @@ proto.examplecom.ParentMessageV3.prototype.hasInternalChildMessage = function() 
 
 
 /**
- * repeated InternalChildMessage internal_children = 2;
+ * optional InternalChildMessage opt_internal_child_message = 2;
+ * @return {?proto.examplecom.ParentMessageV3.InternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptInternalChildMessage = function() {
+  return /** @type{?proto.examplecom.ParentMessageV3.InternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+};
+
+
+/**
+ * @param {?proto.examplecom.ParentMessageV3.InternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptInternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptInternalChildMessage = function() {
+  return this.setOptInternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptInternalChildMessage = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * repeated InternalChildMessage internal_children = 3;
  * @return {!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() {
   return /** @type{!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 3));
 };
 
 
@@ -408,7 +473,7 @@ proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 2, value);
+  return jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
 
 
@@ -418,7 +483,7 @@ proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(va
  * @return {!proto.examplecom.ParentMessageV3.InternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addInternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
 };
 
 
@@ -432,12 +497,12 @@ proto.examplecom.ParentMessageV3.prototype.clearInternalChildrenList = function(
 
 
 /**
- * optional othercom.ExternalChildMessage external_child_message = 3;
+ * optional othercom.ExternalChildMessage external_child_message = 4;
  * @return {?proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() {
   return /** @type{?proto.othercom.ExternalChildMessage} */ (
-    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 3));
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
 };
 
 
@@ -446,7 +511,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildMessage = function(value) {
-  return jspb.Message.setWrapperField(this, 3, value);
+  return jspb.Message.setWrapperField(this, 4, value);
 };
 
 
@@ -464,17 +529,54 @@ proto.examplecom.ParentMessageV3.prototype.clearExternalChildMessage = function(
  * @return {boolean}
  */
 proto.examplecom.ParentMessageV3.prototype.hasExternalChildMessage = function() {
-  return jspb.Message.getField(this, 3) != null;
+  return jspb.Message.getField(this, 4) != null;
 };
 
 
 /**
- * repeated othercom.ExternalChildMessage external_children = 4;
+ * optional othercom.ExternalChildMessage opt_external_child_message = 5;
+ * @return {?proto.othercom.ExternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptExternalChildMessage = function() {
+  return /** @type{?proto.othercom.ExternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 5));
+};
+
+
+/**
+ * @param {?proto.othercom.ExternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptExternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptExternalChildMessage = function() {
+  return this.setOptExternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptExternalChildMessage = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * repeated othercom.ExternalChildMessage external_children = 6;
  * @return {!Array<!proto.othercom.ExternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() {
   return /** @type{!Array<!proto.othercom.ExternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
+    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 6));
 };
 
 
@@ -483,7 +585,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 4, value);
+  return jspb.Message.setRepeatedWrapperField(this, 6, value);
 };
 
 
@@ -493,7 +595,7 @@ proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(va
  * @return {!proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addExternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.othercom.ExternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 6, opt_value, proto.othercom.ExternalChildMessage, opt_index);
 };
 
 

--- a/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -54,6 +54,88 @@ export class PrimitiveMessageV3 extends jspb.Message {
   getMyNumber(): number;
   setMyNumber(value: number): void;
 
+  hasOptDouble(): boolean;
+  clearOptDouble(): void;
+  getOptDouble(): number;
+  setOptDouble(value: number): void;
+
+  hasOptFloat(): boolean;
+  clearOptFloat(): void;
+  getOptFloat(): number;
+  setOptFloat(value: number): void;
+
+  hasOptInt32(): boolean;
+  clearOptInt32(): void;
+  getOptInt32(): number;
+  setOptInt32(value: number): void;
+
+  hasOptInt64(): boolean;
+  clearOptInt64(): void;
+  getOptInt64(): number;
+  setOptInt64(value: number): void;
+
+  hasOptUint32(): boolean;
+  clearOptUint32(): void;
+  getOptUint32(): number;
+  setOptUint32(value: number): void;
+
+  hasOptUint64(): boolean;
+  clearOptUint64(): void;
+  getOptUint64(): number;
+  setOptUint64(value: number): void;
+
+  hasOptSint32(): boolean;
+  clearOptSint32(): void;
+  getOptSint32(): number;
+  setOptSint32(value: number): void;
+
+  hasOptSint64(): boolean;
+  clearOptSint64(): void;
+  getOptSint64(): number;
+  setOptSint64(value: number): void;
+
+  hasOptFixed32(): boolean;
+  clearOptFixed32(): void;
+  getOptFixed32(): number;
+  setOptFixed32(value: number): void;
+
+  hasOptFixed64(): boolean;
+  clearOptFixed64(): void;
+  getOptFixed64(): number;
+  setOptFixed64(value: number): void;
+
+  hasOptSfixed32(): boolean;
+  clearOptSfixed32(): void;
+  getOptSfixed32(): number;
+  setOptSfixed32(value: number): void;
+
+  hasOptSfixed64(): boolean;
+  clearOptSfixed64(): void;
+  getOptSfixed64(): number;
+  setOptSfixed64(value: number): void;
+
+  hasOptBool(): boolean;
+  clearOptBool(): void;
+  getOptBool(): boolean;
+  setOptBool(value: boolean): void;
+
+  hasOptString(): boolean;
+  clearOptString(): void;
+  getOptString(): string;
+  setOptString(value: string): void;
+
+  hasOptBytes(): boolean;
+  clearOptBytes(): void;
+  getOptBytes(): Uint8Array | string;
+  getOptBytes_asU8(): Uint8Array;
+  getOptBytes_asB64(): string;
+  setOptBytes(value: Uint8Array | string): void;
+
+  hasOptNumber(): boolean;
+  clearOptNumber(): void;
+  getOptNumber(): number;
+  setOptNumber(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV3): PrimitiveMessageV3.AsObject;
@@ -82,6 +164,22 @@ export namespace PrimitiveMessageV3 {
     myString: string,
     myBytes: Uint8Array | string,
     myNumber: number,
+    optDouble: number,
+    optFloat: number,
+    optInt32: number,
+    optInt64: number,
+    optUint32: number,
+    optUint64: number,
+    optSint32: number,
+    optSint64: number,
+    optFixed32: number,
+    optFixed64: number,
+    optSfixed32: number,
+    optSfixed64: number,
+    optBool: boolean,
+    optString: string,
+    optBytes: Uint8Array | string,
+    optNumber: number,
   }
 }
 

--- a/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.js
+++ b/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.js
@@ -84,7 +84,23 @@ proto.examplecom.PrimitiveMessageV3.toObject = function(includeInstance, msg) {
     myBool: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
     myString: jspb.Message.getFieldWithDefault(msg, 14, ""),
     myBytes: msg.getMyBytes_asB64(),
-    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0)
+    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0),
+    optDouble: jspb.Message.getFloatingPointFieldWithDefault(msg, 17, 0.0),
+    optFloat: jspb.Message.getFloatingPointFieldWithDefault(msg, 18, 0.0),
+    optInt32: jspb.Message.getFieldWithDefault(msg, 19, 0),
+    optInt64: jspb.Message.getFieldWithDefault(msg, 20, 0),
+    optUint32: jspb.Message.getFieldWithDefault(msg, 21, 0),
+    optUint64: jspb.Message.getFieldWithDefault(msg, 22, 0),
+    optSint32: jspb.Message.getFieldWithDefault(msg, 23, 0),
+    optSint64: jspb.Message.getFieldWithDefault(msg, 24, 0),
+    optFixed32: jspb.Message.getFieldWithDefault(msg, 25, 0),
+    optFixed64: jspb.Message.getFieldWithDefault(msg, 26, 0),
+    optSfixed32: jspb.Message.getFieldWithDefault(msg, 27, 0),
+    optSfixed64: jspb.Message.getFieldWithDefault(msg, 28, 0),
+    optBool: jspb.Message.getBooleanFieldWithDefault(msg, 29, false),
+    optString: jspb.Message.getFieldWithDefault(msg, 30, ""),
+    optBytes: msg.getOptBytes_asB64(),
+    optNumber: jspb.Message.getFieldWithDefault(msg, 32, 0)
   };
 
   if (includeInstance) {
@@ -184,6 +200,70 @@ proto.examplecom.PrimitiveMessageV3.deserializeBinaryFromReader = function(msg, 
     case 16:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setMyNumber(value);
+      break;
+    case 17:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setOptDouble(value);
+      break;
+    case 18:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setOptFloat(value);
+      break;
+    case 19:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptInt32(value);
+      break;
+    case 20:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setOptInt64(value);
+      break;
+    case 21:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setOptUint32(value);
+      break;
+    case 22:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOptUint64(value);
+      break;
+    case 23:
+      var value = /** @type {number} */ (reader.readSint32());
+      msg.setOptSint32(value);
+      break;
+    case 24:
+      var value = /** @type {number} */ (reader.readSint64());
+      msg.setOptSint64(value);
+      break;
+    case 25:
+      var value = /** @type {number} */ (reader.readFixed32());
+      msg.setOptFixed32(value);
+      break;
+    case 26:
+      var value = /** @type {number} */ (reader.readFixed64());
+      msg.setOptFixed64(value);
+      break;
+    case 27:
+      var value = /** @type {number} */ (reader.readSfixed32());
+      msg.setOptSfixed32(value);
+      break;
+    case 28:
+      var value = /** @type {number} */ (reader.readSfixed64());
+      msg.setOptSfixed64(value);
+      break;
+    case 29:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOptBool(value);
+      break;
+    case 30:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOptString(value);
+      break;
+    case 31:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setOptBytes(value);
+      break;
+    case 32:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptNumber(value);
       break;
     default:
       reader.skipField();
@@ -323,6 +403,118 @@ proto.examplecom.PrimitiveMessageV3.serializeBinaryToWriter = function(message, 
   if (f !== 0) {
     writer.writeInt32(
       16,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 17));
+  if (f != null) {
+    writer.writeDouble(
+      17,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 18));
+  if (f != null) {
+    writer.writeFloat(
+      18,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 19));
+  if (f != null) {
+    writer.writeInt32(
+      19,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 20));
+  if (f != null) {
+    writer.writeInt64(
+      20,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 21));
+  if (f != null) {
+    writer.writeUint32(
+      21,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 22));
+  if (f != null) {
+    writer.writeUint64(
+      22,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 23));
+  if (f != null) {
+    writer.writeSint32(
+      23,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 24));
+  if (f != null) {
+    writer.writeSint64(
+      24,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 25));
+  if (f != null) {
+    writer.writeFixed32(
+      25,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 26));
+  if (f != null) {
+    writer.writeFixed64(
+      26,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 27));
+  if (f != null) {
+    writer.writeSfixed32(
+      27,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 28));
+  if (f != null) {
+    writer.writeSfixed64(
+      28,
+      f
+    );
+  }
+  f = /** @type {boolean} */ (jspb.Message.getField(message, 29));
+  if (f != null) {
+    writer.writeBool(
+      29,
+      f
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 30));
+  if (f != null) {
+    writer.writeString(
+      30,
+      f
+    );
+  }
+  f = /** @type {!(string|Uint8Array)} */ (jspb.Message.getField(message, 31));
+  if (f != null) {
+    writer.writeBytes(
+      31,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 32));
+  if (f != null) {
+    writer.writeInt32(
+      32,
       f
     );
   }
@@ -638,6 +830,606 @@ proto.examplecom.PrimitiveMessageV3.prototype.getMyNumber = function() {
  */
 proto.examplecom.PrimitiveMessageV3.prototype.setMyNumber = function(value) {
   return jspb.Message.setProto3IntField(this, 16, value);
+};
+
+
+/**
+ * optional double opt_double = 17;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptDouble = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 17, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptDouble = function(value) {
+  return jspb.Message.setField(this, 17, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptDouble = function() {
+  return jspb.Message.setField(this, 17, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptDouble = function() {
+  return jspb.Message.getField(this, 17) != null;
+};
+
+
+/**
+ * optional float opt_float = 18;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFloat = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 18, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFloat = function(value) {
+  return jspb.Message.setField(this, 18, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFloat = function() {
+  return jspb.Message.setField(this, 18, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFloat = function() {
+  return jspb.Message.getField(this, 18) != null;
+};
+
+
+/**
+ * optional int32 opt_int32 = 19;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 19, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt32 = function(value) {
+  return jspb.Message.setField(this, 19, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt32 = function() {
+  return jspb.Message.setField(this, 19, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt32 = function() {
+  return jspb.Message.getField(this, 19) != null;
+};
+
+
+/**
+ * optional int64 opt_int64 = 20;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 20, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt64 = function(value) {
+  return jspb.Message.setField(this, 20, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt64 = function() {
+  return jspb.Message.setField(this, 20, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt64 = function() {
+  return jspb.Message.getField(this, 20) != null;
+};
+
+
+/**
+ * optional uint32 opt_uint32 = 21;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 21, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint32 = function(value) {
+  return jspb.Message.setField(this, 21, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint32 = function() {
+  return jspb.Message.setField(this, 21, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint32 = function() {
+  return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional uint64 opt_uint64 = 22;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 22, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint64 = function(value) {
+  return jspb.Message.setField(this, 22, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint64 = function() {
+  return jspb.Message.setField(this, 22, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint64 = function() {
+  return jspb.Message.getField(this, 22) != null;
+};
+
+
+/**
+ * optional sint32 opt_sint32 = 23;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 23, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint32 = function(value) {
+  return jspb.Message.setField(this, 23, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint32 = function() {
+  return jspb.Message.setField(this, 23, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint32 = function() {
+  return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional sint64 opt_sint64 = 24;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 24, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint64 = function(value) {
+  return jspb.Message.setField(this, 24, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint64 = function() {
+  return jspb.Message.setField(this, 24, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint64 = function() {
+  return jspb.Message.getField(this, 24) != null;
+};
+
+
+/**
+ * optional fixed32 opt_fixed32 = 25;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 25, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed32 = function(value) {
+  return jspb.Message.setField(this, 25, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed32 = function() {
+  return jspb.Message.setField(this, 25, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed32 = function() {
+  return jspb.Message.getField(this, 25) != null;
+};
+
+
+/**
+ * optional fixed64 opt_fixed64 = 26;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 26, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed64 = function(value) {
+  return jspb.Message.setField(this, 26, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed64 = function() {
+  return jspb.Message.setField(this, 26, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed64 = function() {
+  return jspb.Message.getField(this, 26) != null;
+};
+
+
+/**
+ * optional sfixed32 opt_sfixed32 = 27;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 27, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed32 = function(value) {
+  return jspb.Message.setField(this, 27, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed32 = function() {
+  return jspb.Message.setField(this, 27, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed32 = function() {
+  return jspb.Message.getField(this, 27) != null;
+};
+
+
+/**
+ * optional sfixed64 opt_sfixed64 = 28;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 28, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed64 = function(value) {
+  return jspb.Message.setField(this, 28, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed64 = function() {
+  return jspb.Message.setField(this, 28, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed64 = function() {
+  return jspb.Message.getField(this, 28) != null;
+};
+
+
+/**
+ * optional bool opt_bool = 29;
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBool = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 29, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBool = function(value) {
+  return jspb.Message.setField(this, 29, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBool = function() {
+  return jspb.Message.setField(this, 29, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBool = function() {
+  return jspb.Message.getField(this, 29) != null;
+};
+
+
+/**
+ * optional string opt_string = 30;
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptString = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 30, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptString = function(value) {
+  return jspb.Message.setField(this, 30, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptString = function() {
+  return jspb.Message.setField(this, 30, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptString = function() {
+  return jspb.Message.getField(this, 30) != null;
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * @return {!(string|Uint8Array)}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 31, ""));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getOptBytes()));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {!Uint8Array}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getOptBytes()));
+};
+
+
+/**
+ * @param {!(string|Uint8Array)} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBytes = function(value) {
+  return jspb.Message.setField(this, 31, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBytes = function() {
+  return jspb.Message.setField(this, 31, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBytes = function() {
+  return jspb.Message.getField(this, 31) != null;
+};
+
+
+/**
+ * optional int32 opt_NUMBER = 32;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 32, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptNumber = function(value) {
+  return jspb.Message.setField(this, 32, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptNumber = function() {
+  return jspb.Message.setField(this, 32, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptNumber = function() {
+  return jspb.Message.getField(this, 32) != null;
 };
 
 

--- a/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
@@ -10,6 +10,11 @@ export class ParentMessageV3 extends jspb.Message {
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
   setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
 
+  hasOptInternalChildMessage(): boolean;
+  clearOptInternalChildMessage(): void;
+  getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
   setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
@@ -19,6 +24,11 @@ export class ParentMessageV3 extends jspb.Message {
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
   setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+
+  hasOptExternalChildMessage(): boolean;
+  clearOptExternalChildMessage(): void;
+  getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
@@ -38,8 +48,10 @@ export class ParentMessageV3 extends jspb.Message {
 export namespace ParentMessageV3 {
   export type AsObject = {
     internalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
+    optInternalChildMessage?: ParentMessageV3.InternalChildMessage.AsObject,
     internalChildrenList: Array<ParentMessageV3.InternalChildMessage.AsObject>,
     externalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
+    optExternalChildMessage?: proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject,
     externalChildrenList: Array<proto_othercom_external_child_message_pb.ExternalChildMessage.AsObject>,
   }
 

--- a/examples/generated/proto/examplecom/parent_message_v3_pb.js
+++ b/examples/generated/proto/examplecom/parent_message_v3_pb.js
@@ -67,7 +67,7 @@ if (goog.DEBUG && !COMPILED) {
  * @private {!Array<number>}
  * @const
  */
-proto.examplecom.ParentMessageV3.repeatedFields_ = [2,4];
+proto.examplecom.ParentMessageV3.repeatedFields_ = [3,6];
 
 
 
@@ -101,9 +101,11 @@ proto.examplecom.ParentMessageV3.prototype.toObject = function(opt_includeInstan
 proto.examplecom.ParentMessageV3.toObject = function(includeInstance, msg) {
   var f, obj = {
     internalChildMessage: (f = msg.getInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
+    optInternalChildMessage: (f = msg.getOptInternalChildMessage()) && proto.examplecom.ParentMessageV3.InternalChildMessage.toObject(includeInstance, f),
     internalChildrenList: jspb.Message.toObjectList(msg.getInternalChildrenList(),
     proto.examplecom.ParentMessageV3.InternalChildMessage.toObject, includeInstance),
     externalChildMessage: (f = msg.getExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
+    optExternalChildMessage: (f = msg.getOptExternalChildMessage()) && proto_othercom_external_child_message_pb.ExternalChildMessage.toObject(includeInstance, f),
     externalChildrenList: jspb.Message.toObjectList(msg.getExternalChildrenList(),
     proto_othercom_external_child_message_pb.ExternalChildMessage.toObject, includeInstance)
   };
@@ -150,14 +152,24 @@ proto.examplecom.ParentMessageV3.deserializeBinaryFromReader = function(msg, rea
     case 2:
       var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
       reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
-      msg.addInternalChildren(value);
+      msg.setOptInternalChildMessage(value);
       break;
     case 3:
+      var value = new proto.examplecom.ParentMessageV3.InternalChildMessage;
+      reader.readMessage(value,proto.examplecom.ParentMessageV3.InternalChildMessage.deserializeBinaryFromReader);
+      msg.addInternalChildren(value);
+      break;
+    case 4:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.setExternalChildMessage(value);
       break;
-    case 4:
+    case 5:
+      var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
+      reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
+      msg.setOptExternalChildMessage(value);
+      break;
+    case 6:
       var value = new proto_othercom_external_child_message_pb.ExternalChildMessage;
       reader.readMessage(value,proto_othercom_external_child_message_pb.ExternalChildMessage.deserializeBinaryFromReader);
       msg.addExternalChildren(value);
@@ -199,10 +211,18 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
   }
+  f = message.getOptInternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
+    );
+  }
   f = message.getInternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      2,
+      3,
       f,
       proto.examplecom.ParentMessageV3.InternalChildMessage.serializeBinaryToWriter
     );
@@ -210,7 +230,15 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildMessage();
   if (f != null) {
     writer.writeMessage(
-      3,
+      4,
+      f,
+      proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
+    );
+  }
+  f = message.getOptExternalChildMessage();
+  if (f != null) {
+    writer.writeMessage(
+      5,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -218,7 +246,7 @@ proto.examplecom.ParentMessageV3.serializeBinaryToWriter = function(message, wri
   f = message.getExternalChildrenList();
   if (f.length > 0) {
     writer.writeRepeatedMessage(
-      4,
+      6,
       f,
       proto_othercom_external_child_message_pb.ExternalChildMessage.serializeBinaryToWriter
     );
@@ -394,12 +422,49 @@ proto.examplecom.ParentMessageV3.prototype.hasInternalChildMessage = function() 
 
 
 /**
- * repeated InternalChildMessage internal_children = 2;
+ * optional InternalChildMessage opt_internal_child_message = 2;
+ * @return {?proto.examplecom.ParentMessageV3.InternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptInternalChildMessage = function() {
+  return /** @type{?proto.examplecom.ParentMessageV3.InternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+};
+
+
+/**
+ * @param {?proto.examplecom.ParentMessageV3.InternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptInternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptInternalChildMessage = function() {
+  return this.setOptInternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptInternalChildMessage = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * repeated InternalChildMessage internal_children = 3;
  * @return {!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() {
   return /** @type{!Array<!proto.examplecom.ParentMessageV3.InternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 2));
+    jspb.Message.getRepeatedWrapperField(this, proto.examplecom.ParentMessageV3.InternalChildMessage, 3));
 };
 
 
@@ -408,7 +473,7 @@ proto.examplecom.ParentMessageV3.prototype.getInternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 2, value);
+  return jspb.Message.setRepeatedWrapperField(this, 3, value);
 };
 
 
@@ -418,7 +483,7 @@ proto.examplecom.ParentMessageV3.prototype.setInternalChildrenList = function(va
  * @return {!proto.examplecom.ParentMessageV3.InternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addInternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 2, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 3, opt_value, proto.examplecom.ParentMessageV3.InternalChildMessage, opt_index);
 };
 
 
@@ -432,12 +497,12 @@ proto.examplecom.ParentMessageV3.prototype.clearInternalChildrenList = function(
 
 
 /**
- * optional othercom.ExternalChildMessage external_child_message = 3;
+ * optional othercom.ExternalChildMessage external_child_message = 4;
  * @return {?proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() {
   return /** @type{?proto.othercom.ExternalChildMessage} */ (
-    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 3));
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
 };
 
 
@@ -446,7 +511,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildMessage = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildMessage = function(value) {
-  return jspb.Message.setWrapperField(this, 3, value);
+  return jspb.Message.setWrapperField(this, 4, value);
 };
 
 
@@ -464,17 +529,54 @@ proto.examplecom.ParentMessageV3.prototype.clearExternalChildMessage = function(
  * @return {boolean}
  */
 proto.examplecom.ParentMessageV3.prototype.hasExternalChildMessage = function() {
-  return jspb.Message.getField(this, 3) != null;
+  return jspb.Message.getField(this, 4) != null;
 };
 
 
 /**
- * repeated othercom.ExternalChildMessage external_children = 4;
+ * optional othercom.ExternalChildMessage opt_external_child_message = 5;
+ * @return {?proto.othercom.ExternalChildMessage}
+ */
+proto.examplecom.ParentMessageV3.prototype.getOptExternalChildMessage = function() {
+  return /** @type{?proto.othercom.ExternalChildMessage} */ (
+    jspb.Message.getWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 5));
+};
+
+
+/**
+ * @param {?proto.othercom.ExternalChildMessage|undefined} value
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+*/
+proto.examplecom.ParentMessageV3.prototype.setOptExternalChildMessage = function(value) {
+  return jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.examplecom.ParentMessageV3} returns this
+ */
+proto.examplecom.ParentMessageV3.prototype.clearOptExternalChildMessage = function() {
+  return this.setOptExternalChildMessage(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.ParentMessageV3.prototype.hasOptExternalChildMessage = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * repeated othercom.ExternalChildMessage external_children = 6;
  * @return {!Array<!proto.othercom.ExternalChildMessage>}
  */
 proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() {
   return /** @type{!Array<!proto.othercom.ExternalChildMessage>} */ (
-    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 4));
+    jspb.Message.getRepeatedWrapperField(this, proto_othercom_external_child_message_pb.ExternalChildMessage, 6));
 };
 
 
@@ -483,7 +585,7 @@ proto.examplecom.ParentMessageV3.prototype.getExternalChildrenList = function() 
  * @return {!proto.examplecom.ParentMessageV3} returns this
 */
 proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(value) {
-  return jspb.Message.setRepeatedWrapperField(this, 4, value);
+  return jspb.Message.setRepeatedWrapperField(this, 6, value);
 };
 
 
@@ -493,7 +595,7 @@ proto.examplecom.ParentMessageV3.prototype.setExternalChildrenList = function(va
  * @return {!proto.othercom.ExternalChildMessage}
  */
 proto.examplecom.ParentMessageV3.prototype.addExternalChildren = function(opt_value, opt_index) {
-  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.othercom.ExternalChildMessage, opt_index);
+  return jspb.Message.addToRepeatedWrapperField(this, 6, opt_value, proto.othercom.ExternalChildMessage, opt_index);
 };
 
 

--- a/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -54,6 +54,88 @@ export class PrimitiveMessageV3 extends jspb.Message {
   getMyNumber(): number;
   setMyNumber(value: number): void;
 
+  hasOptDouble(): boolean;
+  clearOptDouble(): void;
+  getOptDouble(): number;
+  setOptDouble(value: number): void;
+
+  hasOptFloat(): boolean;
+  clearOptFloat(): void;
+  getOptFloat(): number;
+  setOptFloat(value: number): void;
+
+  hasOptInt32(): boolean;
+  clearOptInt32(): void;
+  getOptInt32(): number;
+  setOptInt32(value: number): void;
+
+  hasOptInt64(): boolean;
+  clearOptInt64(): void;
+  getOptInt64(): number;
+  setOptInt64(value: number): void;
+
+  hasOptUint32(): boolean;
+  clearOptUint32(): void;
+  getOptUint32(): number;
+  setOptUint32(value: number): void;
+
+  hasOptUint64(): boolean;
+  clearOptUint64(): void;
+  getOptUint64(): number;
+  setOptUint64(value: number): void;
+
+  hasOptSint32(): boolean;
+  clearOptSint32(): void;
+  getOptSint32(): number;
+  setOptSint32(value: number): void;
+
+  hasOptSint64(): boolean;
+  clearOptSint64(): void;
+  getOptSint64(): number;
+  setOptSint64(value: number): void;
+
+  hasOptFixed32(): boolean;
+  clearOptFixed32(): void;
+  getOptFixed32(): number;
+  setOptFixed32(value: number): void;
+
+  hasOptFixed64(): boolean;
+  clearOptFixed64(): void;
+  getOptFixed64(): number;
+  setOptFixed64(value: number): void;
+
+  hasOptSfixed32(): boolean;
+  clearOptSfixed32(): void;
+  getOptSfixed32(): number;
+  setOptSfixed32(value: number): void;
+
+  hasOptSfixed64(): boolean;
+  clearOptSfixed64(): void;
+  getOptSfixed64(): number;
+  setOptSfixed64(value: number): void;
+
+  hasOptBool(): boolean;
+  clearOptBool(): void;
+  getOptBool(): boolean;
+  setOptBool(value: boolean): void;
+
+  hasOptString(): boolean;
+  clearOptString(): void;
+  getOptString(): string;
+  setOptString(value: string): void;
+
+  hasOptBytes(): boolean;
+  clearOptBytes(): void;
+  getOptBytes(): Uint8Array | string;
+  getOptBytes_asU8(): Uint8Array;
+  getOptBytes_asB64(): string;
+  setOptBytes(value: Uint8Array | string): void;
+
+  hasOptNumber(): boolean;
+  clearOptNumber(): void;
+  getOptNumber(): number;
+  setOptNumber(value: number): void;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;
   static toObject(includeInstance: boolean, msg: PrimitiveMessageV3): PrimitiveMessageV3.AsObject;
@@ -82,6 +164,22 @@ export namespace PrimitiveMessageV3 {
     myString: string,
     myBytes: Uint8Array | string,
     myNumber: number,
+    optDouble: number,
+    optFloat: number,
+    optInt32: number,
+    optInt64: number,
+    optUint32: number,
+    optUint64: number,
+    optSint32: number,
+    optSint64: number,
+    optFixed32: number,
+    optFixed64: number,
+    optSfixed32: number,
+    optSfixed64: number,
+    optBool: boolean,
+    optString: string,
+    optBytes: Uint8Array | string,
+    optNumber: number,
   }
 }
 

--- a/examples/generated/proto/examplecom/primitive_message_v3_pb.js
+++ b/examples/generated/proto/examplecom/primitive_message_v3_pb.js
@@ -84,7 +84,23 @@ proto.examplecom.PrimitiveMessageV3.toObject = function(includeInstance, msg) {
     myBool: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
     myString: jspb.Message.getFieldWithDefault(msg, 14, ""),
     myBytes: msg.getMyBytes_asB64(),
-    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0)
+    myNumber: jspb.Message.getFieldWithDefault(msg, 16, 0),
+    optDouble: jspb.Message.getFloatingPointFieldWithDefault(msg, 17, 0.0),
+    optFloat: jspb.Message.getFloatingPointFieldWithDefault(msg, 18, 0.0),
+    optInt32: jspb.Message.getFieldWithDefault(msg, 19, 0),
+    optInt64: jspb.Message.getFieldWithDefault(msg, 20, 0),
+    optUint32: jspb.Message.getFieldWithDefault(msg, 21, 0),
+    optUint64: jspb.Message.getFieldWithDefault(msg, 22, 0),
+    optSint32: jspb.Message.getFieldWithDefault(msg, 23, 0),
+    optSint64: jspb.Message.getFieldWithDefault(msg, 24, 0),
+    optFixed32: jspb.Message.getFieldWithDefault(msg, 25, 0),
+    optFixed64: jspb.Message.getFieldWithDefault(msg, 26, 0),
+    optSfixed32: jspb.Message.getFieldWithDefault(msg, 27, 0),
+    optSfixed64: jspb.Message.getFieldWithDefault(msg, 28, 0),
+    optBool: jspb.Message.getBooleanFieldWithDefault(msg, 29, false),
+    optString: jspb.Message.getFieldWithDefault(msg, 30, ""),
+    optBytes: msg.getOptBytes_asB64(),
+    optNumber: jspb.Message.getFieldWithDefault(msg, 32, 0)
   };
 
   if (includeInstance) {
@@ -184,6 +200,70 @@ proto.examplecom.PrimitiveMessageV3.deserializeBinaryFromReader = function(msg, 
     case 16:
       var value = /** @type {number} */ (reader.readInt32());
       msg.setMyNumber(value);
+      break;
+    case 17:
+      var value = /** @type {number} */ (reader.readDouble());
+      msg.setOptDouble(value);
+      break;
+    case 18:
+      var value = /** @type {number} */ (reader.readFloat());
+      msg.setOptFloat(value);
+      break;
+    case 19:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptInt32(value);
+      break;
+    case 20:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setOptInt64(value);
+      break;
+    case 21:
+      var value = /** @type {number} */ (reader.readUint32());
+      msg.setOptUint32(value);
+      break;
+    case 22:
+      var value = /** @type {number} */ (reader.readUint64());
+      msg.setOptUint64(value);
+      break;
+    case 23:
+      var value = /** @type {number} */ (reader.readSint32());
+      msg.setOptSint32(value);
+      break;
+    case 24:
+      var value = /** @type {number} */ (reader.readSint64());
+      msg.setOptSint64(value);
+      break;
+    case 25:
+      var value = /** @type {number} */ (reader.readFixed32());
+      msg.setOptFixed32(value);
+      break;
+    case 26:
+      var value = /** @type {number} */ (reader.readFixed64());
+      msg.setOptFixed64(value);
+      break;
+    case 27:
+      var value = /** @type {number} */ (reader.readSfixed32());
+      msg.setOptSfixed32(value);
+      break;
+    case 28:
+      var value = /** @type {number} */ (reader.readSfixed64());
+      msg.setOptSfixed64(value);
+      break;
+    case 29:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOptBool(value);
+      break;
+    case 30:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setOptString(value);
+      break;
+    case 31:
+      var value = /** @type {!Uint8Array} */ (reader.readBytes());
+      msg.setOptBytes(value);
+      break;
+    case 32:
+      var value = /** @type {number} */ (reader.readInt32());
+      msg.setOptNumber(value);
       break;
     default:
       reader.skipField();
@@ -323,6 +403,118 @@ proto.examplecom.PrimitiveMessageV3.serializeBinaryToWriter = function(message, 
   if (f !== 0) {
     writer.writeInt32(
       16,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 17));
+  if (f != null) {
+    writer.writeDouble(
+      17,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 18));
+  if (f != null) {
+    writer.writeFloat(
+      18,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 19));
+  if (f != null) {
+    writer.writeInt32(
+      19,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 20));
+  if (f != null) {
+    writer.writeInt64(
+      20,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 21));
+  if (f != null) {
+    writer.writeUint32(
+      21,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 22));
+  if (f != null) {
+    writer.writeUint64(
+      22,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 23));
+  if (f != null) {
+    writer.writeSint32(
+      23,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 24));
+  if (f != null) {
+    writer.writeSint64(
+      24,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 25));
+  if (f != null) {
+    writer.writeFixed32(
+      25,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 26));
+  if (f != null) {
+    writer.writeFixed64(
+      26,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 27));
+  if (f != null) {
+    writer.writeSfixed32(
+      27,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 28));
+  if (f != null) {
+    writer.writeSfixed64(
+      28,
+      f
+    );
+  }
+  f = /** @type {boolean} */ (jspb.Message.getField(message, 29));
+  if (f != null) {
+    writer.writeBool(
+      29,
+      f
+    );
+  }
+  f = /** @type {string} */ (jspb.Message.getField(message, 30));
+  if (f != null) {
+    writer.writeString(
+      30,
+      f
+    );
+  }
+  f = /** @type {!(string|Uint8Array)} */ (jspb.Message.getField(message, 31));
+  if (f != null) {
+    writer.writeBytes(
+      31,
+      f
+    );
+  }
+  f = /** @type {number} */ (jspb.Message.getField(message, 32));
+  if (f != null) {
+    writer.writeInt32(
+      32,
       f
     );
   }
@@ -638,6 +830,606 @@ proto.examplecom.PrimitiveMessageV3.prototype.getMyNumber = function() {
  */
 proto.examplecom.PrimitiveMessageV3.prototype.setMyNumber = function(value) {
   return jspb.Message.setProto3IntField(this, 16, value);
+};
+
+
+/**
+ * optional double opt_double = 17;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptDouble = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 17, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptDouble = function(value) {
+  return jspb.Message.setField(this, 17, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptDouble = function() {
+  return jspb.Message.setField(this, 17, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptDouble = function() {
+  return jspb.Message.getField(this, 17) != null;
+};
+
+
+/**
+ * optional float opt_float = 18;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFloat = function() {
+  return /** @type {number} */ (jspb.Message.getFloatingPointFieldWithDefault(this, 18, 0.0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFloat = function(value) {
+  return jspb.Message.setField(this, 18, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFloat = function() {
+  return jspb.Message.setField(this, 18, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFloat = function() {
+  return jspb.Message.getField(this, 18) != null;
+};
+
+
+/**
+ * optional int32 opt_int32 = 19;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 19, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt32 = function(value) {
+  return jspb.Message.setField(this, 19, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt32 = function() {
+  return jspb.Message.setField(this, 19, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt32 = function() {
+  return jspb.Message.getField(this, 19) != null;
+};
+
+
+/**
+ * optional int64 opt_int64 = 20;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptInt64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 20, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptInt64 = function(value) {
+  return jspb.Message.setField(this, 20, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptInt64 = function() {
+  return jspb.Message.setField(this, 20, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptInt64 = function() {
+  return jspb.Message.getField(this, 20) != null;
+};
+
+
+/**
+ * optional uint32 opt_uint32 = 21;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 21, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint32 = function(value) {
+  return jspb.Message.setField(this, 21, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint32 = function() {
+  return jspb.Message.setField(this, 21, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint32 = function() {
+  return jspb.Message.getField(this, 21) != null;
+};
+
+
+/**
+ * optional uint64 opt_uint64 = 22;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptUint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 22, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptUint64 = function(value) {
+  return jspb.Message.setField(this, 22, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptUint64 = function() {
+  return jspb.Message.setField(this, 22, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptUint64 = function() {
+  return jspb.Message.getField(this, 22) != null;
+};
+
+
+/**
+ * optional sint32 opt_sint32 = 23;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 23, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint32 = function(value) {
+  return jspb.Message.setField(this, 23, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint32 = function() {
+  return jspb.Message.setField(this, 23, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint32 = function() {
+  return jspb.Message.getField(this, 23) != null;
+};
+
+
+/**
+ * optional sint64 opt_sint64 = 24;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSint64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 24, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSint64 = function(value) {
+  return jspb.Message.setField(this, 24, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSint64 = function() {
+  return jspb.Message.setField(this, 24, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSint64 = function() {
+  return jspb.Message.getField(this, 24) != null;
+};
+
+
+/**
+ * optional fixed32 opt_fixed32 = 25;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 25, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed32 = function(value) {
+  return jspb.Message.setField(this, 25, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed32 = function() {
+  return jspb.Message.setField(this, 25, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed32 = function() {
+  return jspb.Message.getField(this, 25) != null;
+};
+
+
+/**
+ * optional fixed64 opt_fixed64 = 26;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptFixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 26, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptFixed64 = function(value) {
+  return jspb.Message.setField(this, 26, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptFixed64 = function() {
+  return jspb.Message.setField(this, 26, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptFixed64 = function() {
+  return jspb.Message.getField(this, 26) != null;
+};
+
+
+/**
+ * optional sfixed32 opt_sfixed32 = 27;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed32 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 27, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed32 = function(value) {
+  return jspb.Message.setField(this, 27, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed32 = function() {
+  return jspb.Message.setField(this, 27, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed32 = function() {
+  return jspb.Message.getField(this, 27) != null;
+};
+
+
+/**
+ * optional sfixed64 opt_sfixed64 = 28;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptSfixed64 = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 28, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptSfixed64 = function(value) {
+  return jspb.Message.setField(this, 28, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptSfixed64 = function() {
+  return jspb.Message.setField(this, 28, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptSfixed64 = function() {
+  return jspb.Message.getField(this, 28) != null;
+};
+
+
+/**
+ * optional bool opt_bool = 29;
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBool = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 29, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBool = function(value) {
+  return jspb.Message.setField(this, 29, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBool = function() {
+  return jspb.Message.setField(this, 29, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBool = function() {
+  return jspb.Message.getField(this, 29) != null;
+};
+
+
+/**
+ * optional string opt_string = 30;
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptString = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 30, ""));
+};
+
+
+/**
+ * @param {string} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptString = function(value) {
+  return jspb.Message.setField(this, 30, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptString = function() {
+  return jspb.Message.setField(this, 30, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptString = function() {
+  return jspb.Message.getField(this, 30) != null;
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * @return {!(string|Uint8Array)}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes = function() {
+  return /** @type {!(string|Uint8Array)} */ (jspb.Message.getFieldWithDefault(this, 31, ""));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {string}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asB64 = function() {
+  return /** @type {string} */ (jspb.Message.bytesAsB64(
+      this.getOptBytes()));
+};
+
+
+/**
+ * optional bytes opt_bytes = 31;
+ * Note that Uint8Array is not supported on all browsers.
+ * @see http://caniuse.com/Uint8Array
+ * This is a type-conversion wrapper around `getOptBytes()`
+ * @return {!Uint8Array}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptBytes_asU8 = function() {
+  return /** @type {!Uint8Array} */ (jspb.Message.bytesAsU8(
+      this.getOptBytes()));
+};
+
+
+/**
+ * @param {!(string|Uint8Array)} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptBytes = function(value) {
+  return jspb.Message.setField(this, 31, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptBytes = function() {
+  return jspb.Message.setField(this, 31, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptBytes = function() {
+  return jspb.Message.getField(this, 31) != null;
+};
+
+
+/**
+ * optional int32 opt_NUMBER = 32;
+ * @return {number}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.getOptNumber = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 32, 0));
+};
+
+
+/**
+ * @param {number} value
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.setOptNumber = function(value) {
+  return jspb.Message.setField(this, 32, value);
+};
+
+
+/**
+ * Clears the field making it undefined.
+ * @return {!proto.examplecom.PrimitiveMessageV3} returns this
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.clearOptNumber = function() {
+  return jspb.Message.setField(this, 32, undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.examplecom.PrimitiveMessageV3.prototype.hasOptNumber = function() {
+  return jspb.Message.getField(this, 32) != null;
 };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+      "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.12.13"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@improbable-eng/grpc-web": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.9.1.tgz",
-      "integrity": "sha512-KAF0C1ev6fqTF4gC5Bwj4yB1L3Z17oCJe5teNFkETBuDyUKSf/0k9WaBiV/DsIXI3ulv4lA4qEOB4PO9jd0X7w==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@improbable-eng/grpc-web/-/grpc-web-0.9.6.tgz",
+      "integrity": "sha512-Qs4++T+UvFmrgELd70VX9WbqiP22rk+a28fiwmerrCfrb2gt+mYAqO5xa5GxvHnL+geXcCbgZOeVWxQXrvXB4Q==",
       "dev": true,
       "requires": {
         "browser-headers": "^0.4.0"
@@ -30,15 +56,15 @@
       "dev": true
     },
     "@types/google-protobuf": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.4.tgz",
-      "integrity": "sha512-6PjMFKl13cgB4kRdYtvyjKl8VVa0PXS2IdVxHhQ8GEKbxBkyJtSbaIeK1eZGjDKN7dvUh4vkOvU9FMwYNv4GQQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.0.tgz",
+      "integrity": "sha512-IshlR1QWD9LYQRlYMfF8dG6PqxrZHddlWB8O5+HCGwH1nv2JQ887fMwRRlXOmUEFehvg+k1THx2h7RbqPUPkGA==",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.109",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.109.tgz",
-      "integrity": "sha512-hop8SdPUEzbcJm6aTsmuwjIYQo1tqLseKCM+s2bBqTU2gErwI4fE+aqUVOlscPSQbKHKgtMMPoC+h4AIGOJYvw==",
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
     "@types/long": {
@@ -54,9 +80,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "7.0.65",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.65.tgz",
-      "integrity": "sha512-iUdyWWikcQnGvIZnYh5ZxnxeREykndA9+iGdo068NGNutibWknDjmmNMq/8cnS1eaTCcgqJsPsFppw3XJWNlUg==",
+      "version": "7.10.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
+      "integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA==",
       "dev": true
     },
     "abbrev": {
@@ -97,9 +123,9 @@
       }
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -139,60 +165,22 @@
       "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
       "dev": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
@@ -222,13 +210,13 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
-      "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
@@ -260,9 +248,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -280,6 +268,16 @@
         "long": "~3"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -294,14 +292,6 @@
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        }
       }
     },
     "caw": {
@@ -328,31 +318,14 @@
       }
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "chownr": {
@@ -379,12 +352,12 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -400,9 +373,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "concat-map": {
@@ -434,6 +407,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "core-util-is": {
@@ -441,6 +422,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -452,12 +446,12 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -664,9 +658,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -682,23 +676,33 @@
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
         "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
       }
     },
     "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -716,12 +720,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "ext-list": {
@@ -775,6 +773,16 @@
         "trim-repeated": "^1.0.0"
       }
     },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -818,6 +826,17 @@
         "wide-align": "^1.1.0"
       }
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
@@ -840,9 +859,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -854,9 +873,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.15.6",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.6.tgz",
-      "integrity": "sha512-p65NyhIZFHFUxbIPOm6cygg2rCjK+2uDCxruOG3RaWKM9R4rBGX0STmlJoSOhoyAG8Fha7U8FP4pQomAV1JXsA=="
+      "version": "3.15.8",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz",
+      "integrity": "sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw=="
     },
     "got": {
       "version": "7.1.0",
@@ -881,15 +900,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "growl": {
@@ -921,15 +934,6 @@
         "node-pre-gyp": "^0.15.0"
       },
       "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        },
         "node-pre-gyp": {
           "version": "0.15.0",
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
@@ -959,14 +963,11 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -981,9 +982,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-to-string-tag-x": {
@@ -1008,30 +1009,10 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
-      "integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
-      }
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1043,9 +1024,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore-walk": {
@@ -1077,15 +1058,15 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "invert-kv": {
@@ -1100,26 +1081,47 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
       "dev": true
     },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
     "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -1136,10 +1138,22 @@
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
       "dev": true
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
     "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
     "is-plain-obj": {
@@ -1149,18 +1163,19 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
       }
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -1169,13 +1184,19 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-utf8": {
@@ -1207,15 +1228,15 @@
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1238,21 +1259,30 @@
       }
     },
     "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -1305,9 +1335,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
-      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "map-obj": {
@@ -1338,102 +1368,12 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
       "dev": true
     },
     "mimic-response": {
@@ -1477,20 +1417,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -1512,38 +1444,6 @@
         "supports-color": "5.4.0"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "mocha-spec-json-output-reporter": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mocha-spec-json-output-reporter/-/mocha-spec-json-output-reporter-1.1.6.tgz",
-      "integrity": "sha1-iBxKCDcKn3bbFQ+yMFTjDMPjcnA=",
-      "dev": true,
-      "requires": {
-        "mocha": "^5.0.2",
-        "moment": "^2.21.0"
-      },
-      "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-          "dev": true
-        },
         "commander": {
           "version": "2.15.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
@@ -1573,58 +1473,49 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "growl": {
-          "version": "1.10.5",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        },
-        "mocha": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.1",
-            "commander": "2.15.1",
-            "debug": "3.1.0",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.5",
-            "he": "1.1.1",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "supports-color": "5.4.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
         }
       }
     },
+    "mocha-spec-json-output-reporter": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-spec-json-output-reporter/-/mocha-spec-json-output-reporter-1.1.7.tgz",
+      "integrity": "sha512-Fn0GdoX0q/AWz3R5JJCccATzNJNHbM7CcAgeNg6YyTCtAurqXjohuNCZ+3SoA17fU/TBdKbIfcs34gUcrLye2Q==",
+      "dev": true,
+      "requires": {
+        "mocha": "^5.0.2",
+        "moment": "^2.21.0"
+      }
+    },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "nan": {
@@ -1642,23 +1533,6 @@
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
-        }
       }
     },
     "nice-try": {
@@ -1683,17 +1557,6 @@
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
         "tar": "^4.4.2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "nopt": {
@@ -1716,23 +1579,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-          "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "npm-bundled": {
@@ -1788,18 +1634,53 @@
         "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },
@@ -1827,11 +1708,29 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1910,13 +1809,21 @@
       }
     },
     "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1932,18 +1839,28 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "pend": {
@@ -1953,9 +1870,9 @@
       "dev": true
     },
     "pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -1986,9 +1903,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "proto-list": {
@@ -2022,20 +1939,30 @@
       }
     },
     "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
+        "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -2045,6 +1972,14 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "redent": {
@@ -2067,43 +2002,28 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
     "safer-buffer": {
@@ -2119,29 +2039,18 @@
       "dev": true
     },
     "seek-bzip": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
       "dev": true,
       "requires": {
-        "commander": "~2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        }
+        "commander": "^2.8.1"
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "set-blocking": {
@@ -2166,15 +2075,15 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.1.tgz",
-      "integrity": "sha512-2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "sort-keys": {
@@ -2211,9 +2120,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -2221,15 +2130,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -2237,9 +2146,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
     "sprintf-js": {
@@ -2260,14 +2169,34 @@
       }
     },
     "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -2277,6 +2206,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {
@@ -2289,10 +2226,13 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
     },
     "strip-dirs": {
       "version": "2.1.0",
@@ -2400,16 +2340,16 @@
       }
     },
     "ts-node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
       },
       "dependencies": {
         "diff": {
@@ -2425,54 +2365,58 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
-        },
-        "yn": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-          "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-          "dev": true
         }
       }
     },
     "tslib": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
     "tslint": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.10.0.tgz",
-      "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
+        },
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
         }
       }
     },
@@ -2501,15 +2445,27 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.8.tgz",
+      "integrity": "sha512-R97qglMfoKjfKD0N24o7W6bS+SwjN/eaQNIaxR8S5HdLRnt7rCk6LCmE3tve1KN8gXKgbJU51aZHRRMAQcIbMA==",
       "dev": true
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",
@@ -2556,6 +2512,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -2573,7 +2542,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -2629,6 +2598,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@improbable-eng/grpc-web": "^0.9.1",
     "@types/chai": "^3.5.2",
-    "@types/google-protobuf": "^3.7.4",
+    "@types/google-protobuf": "^3.15.0",
     "@types/lodash": "^4.14.106",
     "@types/mocha": "^2.2.46",
     "@types/node": "^7.0.52",

--- a/proto/examplecom/parent_message_v3.proto
+++ b/proto/examplecom/parent_message_v3.proto
@@ -10,8 +10,11 @@ message ParentMessageV3 {
     }
 
     InternalChildMessage internal_child_message = 1;
-    repeated InternalChildMessage internal_children = 2;
+    optional InternalChildMessage opt_internal_child_message = 2;
+    repeated InternalChildMessage internal_children = 3;
 
-    othercom.ExternalChildMessage external_child_message = 3;
-    repeated othercom.ExternalChildMessage external_children = 4;
+
+    othercom.ExternalChildMessage external_child_message = 4;
+    optional othercom.ExternalChildMessage opt_external_child_message = 5;
+    repeated othercom.ExternalChildMessage external_children = 6;
 }

--- a/proto/examplecom/primitive_message_v3.proto
+++ b/proto/examplecom/primitive_message_v3.proto
@@ -20,4 +20,22 @@ message PrimitiveMessageV3 {
     bytes my_bytes = 15;
 
     int32 my_NUMBER = 16;
+
+    optional double opt_double = 17;
+    optional float opt_float = 18;
+    optional int32 opt_int32 = 19;
+    optional int64 opt_int64 = 20;
+    optional uint32 opt_uint32 = 21;
+    optional uint64 opt_uint64 = 22;
+    optional sint32 opt_sint32 = 23;
+    optional sint64 opt_sint64 = 24;
+    optional fixed32 opt_fixed32 = 25;
+    optional fixed64 opt_fixed64 = 26;
+    optional sfixed32 opt_sfixed32 = 27;
+    optional sfixed64 opt_sfixed64 = 28;
+    optional bool opt_bool = 29;
+    optional string opt_string = 30;
+    optional bytes opt_bytes = 31;
+
+    optional int32 opt_NUMBER = 32;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ withAllStdIn((inputBuff: Buffer) => {
 
     const codeGenRequest = CodeGeneratorRequest.deserializeBinary(typedInputBuff);
     const codeGenResponse = new CodeGeneratorResponse();
+    codeGenResponse.setSupportedFeatures(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL);
     const exportMap = new ExportMap();
     const fileNameToDescriptor: {[key: string]: FileDescriptorProto} = {};
 
@@ -54,7 +55,7 @@ withAllStdIn((inputBuff: Buffer) => {
       }
     });
 
-    process.stdout.write(Buffer.from(codeGenResponse.serializeBinary()));
+    process.stdout.write(Buffer.from(codeGenResponse.serializeBinary().buffer));
   } catch (err) {
     console.error("protoc-gen-ts error: " + err.stack + "\n");
     process.exit(1);

--- a/test/integration/nestedMessagesV3.ts
+++ b/test/integration/nestedMessagesV3.ts
@@ -10,7 +10,7 @@ describe("proto3 - internal nested messages", () => {
     assert.deepEqual(parentMsg.getInternalChildrenList() as Array<InternalChildMessage>, []);
   });
 
-  it("should allow setting and getting internal message fields", () => {
+  it("should allow setting and getting normal internal message fields", () => {
     const parentMsg = new ParentMessageV3();
     assert.strictEqual(parentMsg.hasInternalChildMessage(), false);
     const childMsg = new InternalChildMessage();
@@ -26,6 +26,24 @@ describe("proto3 - internal nested messages", () => {
     assert.strictEqual(parentMsg.hasInternalChildMessage(), true);
     parentMsg.clearInternalChildMessage();
     assert.strictEqual(parentMsg.hasInternalChildMessage(), false);
+  });
+
+  it("should allow setting and getting optional internal message fields", () => {
+    const parentMsg = new ParentMessageV3();
+    assert.strictEqual(parentMsg.hasOptInternalChildMessage(), false);
+    const childMsg = new InternalChildMessage();
+    childMsg.setMyString("hello world");
+    parentMsg.setOptInternalChildMessage(childMsg);
+    assert.strictEqual(parentMsg.getOptInternalChildMessage()!.getMyString() as string, "hello world");
+    assert.strictEqual(parentMsg.hasOptInternalChildMessage(), true);
+    parentMsg.setOptInternalChildMessage(undefined);
+    assert.strictEqual(parentMsg.getOptInternalChildMessage() as undefined, undefined);
+    assert.strictEqual(parentMsg.hasOptInternalChildMessage(), false);
+
+    parentMsg.setOptInternalChildMessage(childMsg);
+    assert.strictEqual(parentMsg.hasOptInternalChildMessage(), true);
+    parentMsg.clearOptInternalChildMessage();
+    assert.strictEqual(parentMsg.hasOptInternalChildMessage(), false);
   });
 
   it("should allow setting and getting repeated internal message fields", () => {

--- a/test/integration/primitivesV2.ts
+++ b/test/integration/primitivesV2.ts
@@ -74,37 +74,82 @@ describe("proto2 - primitive", () => {
     assert.strictEqual(msg.getMyBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
   });
 
-  it("should allow setting and getting required optional fields", () => {
+  it("should allow setting and getting optional primitive fields", () => {
     const msg = new PrimitiveMessageV2();
+
+    assert.isFalse(msg.hasOptDouble());
     msg.setOptDouble(123);
+    assert.isTrue(msg.hasOptDouble());
     assert.strictEqual(msg.getOptDouble() as number, 123);
+
+    assert.isFalse(msg.hasOptFloat());
     msg.setOptFloat(123);
+    assert.isTrue(msg.hasOptFloat());
     assert.strictEqual(msg.getOptFloat() as number, 123);
+
+    assert.isFalse(msg.hasOptInt32());
     msg.setOptInt32(123);
+    assert.isTrue(msg.hasOptInt32());
     assert.strictEqual(msg.getOptInt32() as number, 123);
+
+    assert.isFalse(msg.hasOptInt64());
     msg.setOptInt64(123);
+    assert.isTrue(msg.hasOptInt64());
     assert.strictEqual(msg.getOptInt64() as number, 123);
+
+    assert.isFalse(msg.hasOptUint32());
     msg.setOptUint32(123);
+    assert.isTrue(msg.hasOptUint32());
     assert.strictEqual(msg.getOptUint32() as number, 123);
+
+    assert.isFalse(msg.hasOptUint64());
     msg.setOptUint64(123);
+    assert.isTrue(msg.hasOptUint64());
     assert.strictEqual(msg.getOptUint64() as number, 123);
+
+    assert.isFalse(msg.hasOptSint32());
     msg.setOptSint32(123);
+    assert.isTrue(msg.hasOptSint32());
     assert.strictEqual(msg.getOptSint32() as number, 123);
+
+    assert.isFalse(msg.hasOptSint64());
     msg.setOptSint64(123);
+    assert.isTrue(msg.hasOptSint64());
     assert.strictEqual(msg.getOptSint64() as number, 123);
+
+    assert.isFalse(msg.hasOptFixed32());
     msg.setOptFixed32(123);
+    assert.isTrue(msg.hasOptFixed32());
     assert.strictEqual(msg.getOptFixed32() as number, 123);
+
+    assert.isFalse(msg.hasOptFixed64());
     msg.setOptFixed64(123);
+    assert.isTrue(msg.hasOptFixed64());
     assert.strictEqual(msg.getOptFixed64() as number, 123);
+
+    assert.isFalse(msg.hasOptSfixed32());
     msg.setOptSfixed32(123);
+    assert.isTrue(msg.hasOptSfixed32());
     assert.strictEqual(msg.getOptSfixed32() as number, 123);
+
+    assert.isFalse(msg.hasOptSfixed64());
     msg.setOptSfixed64(123);
+    assert.isTrue(msg.hasOptSfixed64());
     assert.strictEqual(msg.getOptSfixed64() as number, 123);
+
+    assert.isFalse(msg.hasOptBool());
     msg.setOptBool(true);
+    assert.isTrue(msg.hasOptBool());
     assert.strictEqual(msg.getOptBool() as boolean, true);
+
+    assert.isFalse(msg.hasOptString());
     msg.setOptString("hello world");
+    assert.isTrue(msg.hasOptString());
     assert.strictEqual(msg.getOptString() as string, "hello world");
+
+    assert.isFalse(msg.hasOptBytes());
     msg.setOptBytes("AAECAwQFBgcICQ==");
+    assert.isTrue(msg.hasOptBytes());
     assert.strictEqual(msg.getOptBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
   });
 

--- a/test/integration/primitivesV3.ts
+++ b/test/integration/primitivesV3.ts
@@ -21,6 +21,25 @@ describe("proto3 - primitive", () => {
     assert.strictEqual(msg.getMyBytes() as (Uint8Array|string), "");
   });
 
+  it("should allow getting optional primitive fields", () => {
+    const msg = new PrimitiveMessageV3();
+    assert.strictEqual(msg.getOptDouble() as number, 0);
+    assert.strictEqual(msg.getOptFloat() as number, 0);
+    assert.strictEqual(msg.getOptInt32() as number, 0);
+    assert.strictEqual(msg.getOptInt64() as number, 0);
+    assert.strictEqual(msg.getOptUint32() as number, 0);
+    assert.strictEqual(msg.getOptUint64() as number, 0);
+    assert.strictEqual(msg.getOptSint32() as number, 0);
+    assert.strictEqual(msg.getOptSint64() as number, 0);
+    assert.strictEqual(msg.getOptFixed32() as number, 0);
+    assert.strictEqual(msg.getOptFixed64() as number, 0);
+    assert.strictEqual(msg.getOptSfixed32() as number, 0);
+    assert.strictEqual(msg.getOptSfixed64() as number, 0);
+    assert.strictEqual(msg.getOptBool() as boolean, false);
+    assert.strictEqual(msg.getOptString() as string, "");
+    assert.strictEqual(msg.getOptBytes() as (Uint8Array|string), "");
+  });
+
   it("should allow setting and getting primitive fields", () => {
     const msg = new PrimitiveMessageV3();
     msg.setMyDouble(123);
@@ -53,6 +72,85 @@ describe("proto3 - primitive", () => {
     assert.strictEqual(msg.getMyString() as string, "hello world");
     msg.setMyBytes("AAECAwQFBgcICQ==");
     assert.strictEqual(msg.getMyBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
+  });
+
+  it("should allow setting and getting optional primitive fields", () => {
+    const msg = new PrimitiveMessageV3();
+
+    assert.isFalse(msg.hasOptDouble());
+    msg.setOptDouble(123);
+    assert.isTrue(msg.hasOptDouble());
+    assert.strictEqual(msg.getOptDouble() as number, 123);
+
+    assert.isFalse(msg.hasOptFloat());
+    msg.setOptFloat(123);
+    assert.isTrue(msg.hasOptFloat());
+    assert.strictEqual(msg.getOptFloat() as number, 123);
+
+    assert.isFalse(msg.hasOptInt32());
+    msg.setOptInt32(123);
+    assert.isTrue(msg.hasOptInt32());
+    assert.strictEqual(msg.getOptInt32() as number, 123);
+
+    assert.isFalse(msg.hasOptInt64());
+    msg.setOptInt64(123);
+    assert.isTrue(msg.hasOptInt64());
+    assert.strictEqual(msg.getOptInt64() as number, 123);
+
+    assert.isFalse(msg.hasOptUint32());
+    msg.setOptUint32(123);
+    assert.isTrue(msg.hasOptUint32());
+    assert.strictEqual(msg.getOptUint32() as number, 123);
+
+    assert.isFalse(msg.hasOptUint64());
+    msg.setOptUint64(123);
+    assert.isTrue(msg.hasOptUint64());
+    assert.strictEqual(msg.getOptUint64() as number, 123);
+
+    assert.isFalse(msg.hasOptSint32());
+    msg.setOptSint32(123);
+    assert.isTrue(msg.hasOptSint32());
+    assert.strictEqual(msg.getOptSint32() as number, 123);
+
+    assert.isFalse(msg.hasOptSint64());
+    msg.setOptSint64(123);
+    assert.isTrue(msg.hasOptSint64());
+    assert.strictEqual(msg.getOptSint64() as number, 123);
+
+    assert.isFalse(msg.hasOptFixed32());
+    msg.setOptFixed32(123);
+    assert.isTrue(msg.hasOptFixed32());
+    assert.strictEqual(msg.getOptFixed32() as number, 123);
+
+    assert.isFalse(msg.hasOptFixed64());
+    msg.setOptFixed64(123);
+    assert.isTrue(msg.hasOptFixed64());
+    assert.strictEqual(msg.getOptFixed64() as number, 123);
+
+    assert.isFalse(msg.hasOptSfixed32());
+    msg.setOptSfixed32(123);
+    assert.isTrue(msg.hasOptSfixed32());
+    assert.strictEqual(msg.getOptSfixed32() as number, 123);
+
+    assert.isFalse(msg.hasOptSfixed64());
+    msg.setOptSfixed64(123);
+    assert.isTrue(msg.hasOptSfixed64());
+    assert.strictEqual(msg.getOptSfixed64() as number, 123);
+
+    assert.isFalse(msg.hasOptBool());
+    msg.setOptBool(true);
+    assert.isTrue(msg.hasOptBool());
+    assert.strictEqual(msg.getOptBool() as boolean, true);
+
+    assert.isFalse(msg.hasOptString());
+    msg.setOptString("hello world");
+    assert.isTrue(msg.hasOptString());
+    assert.strictEqual(msg.getOptString() as string, "hello world");
+
+    assert.isFalse(msg.hasOptBytes());
+    msg.setOptBytes("AAECAwQFBgcICQ==");
+    assert.isTrue(msg.hasOptBytes());
+    assert.strictEqual(msg.getOptBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
   });
 
   it("should allow setting and getting byte values", () => {
@@ -91,6 +189,21 @@ describe("proto3 - primitive", () => {
       assert.strictEqual(asObject.myBool as boolean, false);
       assert.strictEqual(asObject.myString as string, "");
       assert.strictEqual(asObject.myBytes as (Uint8Array|string), "");
+      assert.strictEqual(asObject.optDouble, 0);
+      assert.strictEqual(asObject.optFloat, 0);
+      assert.strictEqual(asObject.optInt32, 0);
+      assert.strictEqual(asObject.optInt64, 0);
+      assert.strictEqual(asObject.optUint32, 0);
+      assert.strictEqual(asObject.optUint64, 0);
+      assert.strictEqual(asObject.optSint32, 0);
+      assert.strictEqual(asObject.optSint64, 0);
+      assert.strictEqual(asObject.optFixed32, 0);
+      assert.strictEqual(asObject.optFixed64, 0);
+      assert.strictEqual(asObject.optSfixed32, 0);
+      assert.strictEqual(asObject.optSfixed64, 0);
+      assert.strictEqual(asObject.optBool, false);
+      assert.strictEqual(asObject.optString, "");
+      assert.strictEqual(asObject.optBytes, "");
     });
     it("should camelcase fully-capitalized field names", () => {
       const msg = new PrimitiveMessageV3();


### PR DESCRIPTION
## Changes

Add implementation for proto3 optional fields with presence tracking. Spec: https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md

Fixes: https://github.com/improbable-eng/ts-protoc-gen/issues/263

Additionally, this change:
- Improves tests for the proto2 scalar messages
- Explicitly calls `.buffer` on the serialized message before passing into `Buffer.from` to handle a weird typescript issue.

## Verification

Tested via unit tests and visual inspection of generated files.
