### PR TITLE
Fix CI failing due to diff caused by npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ deploy:
   tag: "$NPM_TAG"
   on:
     branch: master
-cache:
-  directories:
-  - node_modules
 install:
 - npm install
 script:

--- a/travis-ci-build.sh
+++ b/travis-ci-build.sh
@@ -5,6 +5,9 @@ npm run lint
 npm test
 
 npm run generate
+
+git --no-pager diff
+
 MODIFIED_FILES=$(git diff --name-only)
 if [[ -n $MODIFIED_FILES ]]; then
   echo "ERROR: Changes detected in generated code, please run 'npm run generate' and check-in the changes."


### PR DESCRIPTION
## Changes

* Stopped caching `node_modules` - appears to have negligible impact on CI duration.
* Fixes CI that [appeared to be](https://travis-ci.org/github/improbable-eng/ts-protoc-gen/builds/768112003#L497) hitting a npm issue that [inexplicably downgrades from https to http when `npm install`ing](https://npm.community/t/npm-install-downgrading-resolved-packages-from-https-to-http-registry-in-package-lock-json/1818).

## Verification

* CI passed for this branch
