### PR TITLE
Change return type of generated setters to the message type

### DIFF
--- a/examples/generated-grpc-js-node/proto/examplecom/annotations_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/annotations_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class AnnotatedMessage extends jspb.Message {
   getMyunit64(): string;
-  setMyunit64(value: string): void;
+  setMyunit64(value: string): AnnotatedMessage;
 
   getMyint64(): string;
-  setMyint64(value: string): void;
+  setMyint64(value: string): AnnotatedMessage;
 
   getMyfixed64(): string;
-  setMyfixed64(value: string): void;
+  setMyfixed64(value: string): AnnotatedMessage;
 
   getMysint64(): string;
-  setMysint64(value: string): void;
+  setMysint64(value: string): AnnotatedMessage;
 
   getMysfixed64(): string;
-  setMysfixed64(value: string): void;
+  setMysfixed64(value: string): AnnotatedMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AnnotatedMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/casing_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/casing_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class CasingMessage extends jspb.Message {
   getTitlecase(): string;
-  setTitlecase(value: string): void;
+  setTitlecase(value: string): CasingMessage;
 
   getCamelcase(): string;
-  setCamelcase(value: string): void;
+  setCamelcase(value: string): CasingMessage;
 
   getSnakeCase(): string;
-  setSnakeCase(value: string): void;
+  setSnakeCase(value: string): CasingMessage;
 
   getLeadingunderscorecamelcase(): string;
-  setLeadingunderscorecamelcase(value: string): void;
+  setLeadingunderscorecamelcase(value: string): CasingMessage;
 
   getLeadingunderscoretitlecase(): string;
-  setLeadingunderscoretitlecase(value: string): void;
+  setLeadingunderscoretitlecase(value: string): CasingMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CasingMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/enum_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/enum_message_pb.d.ts
@@ -6,19 +6,19 @@ import * as proto_othercom_external_enum_pb from "../../proto/othercom/external_
 
 export class EnumMessage extends jspb.Message {
   getInternalEnum(): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
-  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): void;
+  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): EnumMessage;
 
   clearInternalEnumsList(): void;
   getInternalEnumsList(): Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>;
-  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): void;
+  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): EnumMessage;
   addInternalEnums(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap], index?: number): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
 
   getExternalEnum(): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
-  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): void;
+  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): EnumMessage;
 
   clearExternalEnumsList(): void;
   getExternalEnumsList(): Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>;
-  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): void;
+  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): EnumMessage;
   addExternalEnums(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap], index?: number): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-js-node/proto/examplecom/extensions_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/extensions_pb.d.ts
@@ -7,7 +7,7 @@ export class ExtensionMessage extends jspb.Message {
   hasMyExtensionString(): boolean;
   clearMyExtensionString(): void;
   getMyExtensionString(): string | undefined;
-  setMyExtensionString(value: string): void;
+  setMyExtensionString(value: string): ExtensionMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExtensionMessage.AsObject;
@@ -29,7 +29,7 @@ export class MyBase extends jspb.Message {
   hasMyBaseString(): boolean;
   clearMyBaseString(): void;
   getMyBaseString(): string | undefined;
-  setMyBaseString(value: string): void;
+  setMyBaseString(value: string): MyBase;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MyBase.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/getter_name_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/getter_name_pb.d.ts
@@ -7,14 +7,14 @@ export class GetterNameConflictMessage extends jspb.Message {
   hasExtension$(): boolean;
   clearExtension$(): void;
   getExtension$(): string | undefined;
-  setExtension$(value: string): void;
+  setExtension$(value: string): GetterNameConflictMessage;
 
   hasJsPbMessageId$(): boolean;
   clearJsPbMessageId$(): void;
   getJsPbMessageId$(): Uint8Array | string;
   getJsPbMessageId_asU8(): Uint8Array;
   getJsPbMessageId_asB64(): string;
-  setJsPbMessageId$(value: Uint8Array | string): void;
+  setJsPbMessageId$(value: Uint8Array | string): GetterNameConflictMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetterNameConflictMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/map_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/map_message_pb.d.ts
@@ -37,7 +37,7 @@ export namespace MapMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/oneof_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/oneof_message_pb.d.ts
@@ -8,22 +8,22 @@ export class OneOfMessage extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): OneOfMessage.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): void;
+  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): OneOfMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): OneOfMessage;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OneOfMessage;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): OneOfMessage;
 
   getGroupCase(): OneOfMessage.GroupCase;
   serializeBinary(): Uint8Array;
@@ -46,7 +46,7 @@ export namespace OneOfMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
@@ -77,12 +77,12 @@ export class CamelCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): CamelCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): CamelCasedOneOfMessage;
 
   getCamelcasedmessageCase(): CamelCasedOneOfMessage.CamelcasedmessageCase;
   serializeBinary(): Uint8Array;
@@ -112,12 +112,12 @@ export class SnakeCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): SnakeCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): SnakeCasedOneOfMessage;
 
   getSnakeCasedMessageCase(): SnakeCasedOneOfMessage.SnakeCasedMessageCase;
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-js-node/proto/examplecom/parent_message_v2_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/parent_message_v2_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV2 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV2.InternalChildMessage;
-  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV2.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV2.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): ParentMessageV2;
   addInternalChildren(value?: ParentMessageV2.InternalChildMessage, index?: number): ParentMessageV2.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV2;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -59,7 +59,7 @@ export namespace ParentMessageV2 {
     hasMyString(): boolean;
     clearMyString(): void;
     getMyString(): string | undefined;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/parent_message_v3_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV3 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): ParentMessageV3;
   addInternalChildren(value?: ParentMessageV3.InternalChildMessage, index?: number): ParentMessageV3.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV3;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -57,7 +57,7 @@ export namespace ParentMessageV3 {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v2_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v2_pb.d.ts
@@ -7,161 +7,161 @@ export class PrimitiveMessageV2 extends jspb.Message {
   hasMyDouble(): boolean;
   clearMyDouble(): void;
   getMyDouble(): number | undefined;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV2;
 
   hasMyFloat(): boolean;
   clearMyFloat(): void;
   getMyFloat(): number | undefined;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV2;
 
   hasMyInt32(): boolean;
   clearMyInt32(): void;
   getMyInt32(): number | undefined;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV2;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number | undefined;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV2;
 
   hasMyUint32(): boolean;
   clearMyUint32(): void;
   getMyUint32(): number | undefined;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV2;
 
   hasMyUint64(): boolean;
   clearMyUint64(): void;
   getMyUint64(): number | undefined;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV2;
 
   hasMySint32(): boolean;
   clearMySint32(): void;
   getMySint32(): number | undefined;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV2;
 
   hasMySint64(): boolean;
   clearMySint64(): void;
   getMySint64(): number | undefined;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV2;
 
   hasMyFixed32(): boolean;
   clearMyFixed32(): void;
   getMyFixed32(): number | undefined;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV2;
 
   hasMyFixed64(): boolean;
   clearMyFixed64(): void;
   getMyFixed64(): number | undefined;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV2;
 
   hasMySfixed32(): boolean;
   clearMySfixed32(): void;
   getMySfixed32(): number | undefined;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV2;
 
   hasMySfixed64(): boolean;
   clearMySfixed64(): void;
   getMySfixed64(): number | undefined;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV2;
 
   hasMyBool(): boolean;
   clearMyBool(): void;
   getMyBool(): boolean | undefined;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV2;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string | undefined;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV2;
 
   hasMyBytes(): boolean;
   clearMyBytes(): void;
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number | undefined;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV2;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number | undefined;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV2;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number | undefined;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV2;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number | undefined;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV2;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number | undefined;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV2;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number | undefined;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV2;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number | undefined;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV2;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number | undefined;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV2;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number | undefined;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV2;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number | undefined;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV2;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number | undefined;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV2;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number | undefined;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV2;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean | undefined;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV2;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string | undefined;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV2;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number | undefined;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV2;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV2.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -5,136 +5,136 @@ import * as jspb from "google-protobuf";
 
 export class PrimitiveMessageV3 extends jspb.Message {
   getMyDouble(): number;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV3;
 
   getMyFloat(): number;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV3;
 
   getMyInt32(): number;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV3;
 
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV3;
 
   getMyUint32(): number;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV3;
 
   getMyUint64(): number;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV3;
 
   getMySint32(): number;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV3;
 
   getMySint64(): number;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV3;
 
   getMyFixed32(): number;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV3;
 
   getMyFixed64(): number;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV3;
 
   getMySfixed32(): number;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV3;
 
   getMySfixed64(): number;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV3;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV3;
 
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV3;
 
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   getMyNumber(): number;
-  setMyNumber(value: number): void;
+  setMyNumber(value: number): PrimitiveMessageV3;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV3;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV3;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV3;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV3;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV3;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV3;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV3;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV3;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV3;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV3;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV3;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV3;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV3;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV3;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV3;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/repeated_primitive_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/repeated_primitive_message_pb.d.ts
@@ -6,79 +6,79 @@ import * as jspb from "google-protobuf";
 export class RepeatedPrimitiveMessage extends jspb.Message {
   clearMyDoubleList(): void;
   getMyDoubleList(): Array<number>;
-  setMyDoubleList(value: Array<number>): void;
+  setMyDoubleList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyDouble(value: number, index?: number): number;
 
   clearMyFloatList(): void;
   getMyFloatList(): Array<number>;
-  setMyFloatList(value: Array<number>): void;
+  setMyFloatList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFloat(value: number, index?: number): number;
 
   clearMyInt32List(): void;
   getMyInt32List(): Array<number>;
-  setMyInt32List(value: Array<number>): void;
+  setMyInt32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt32(value: number, index?: number): number;
 
   clearMyInt64List(): void;
   getMyInt64List(): Array<number>;
-  setMyInt64List(value: Array<number>): void;
+  setMyInt64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt64(value: number, index?: number): number;
 
   clearMyUint32List(): void;
   getMyUint32List(): Array<number>;
-  setMyUint32List(value: Array<number>): void;
+  setMyUint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint32(value: number, index?: number): number;
 
   clearMyUint64List(): void;
   getMyUint64List(): Array<number>;
-  setMyUint64List(value: Array<number>): void;
+  setMyUint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint64(value: number, index?: number): number;
 
   clearMySint32List(): void;
   getMySint32List(): Array<number>;
-  setMySint32List(value: Array<number>): void;
+  setMySint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint32(value: number, index?: number): number;
 
   clearMySint64List(): void;
   getMySint64List(): Array<number>;
-  setMySint64List(value: Array<number>): void;
+  setMySint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint64(value: number, index?: number): number;
 
   clearMyFixed32List(): void;
   getMyFixed32List(): Array<number>;
-  setMyFixed32List(value: Array<number>): void;
+  setMyFixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed32(value: number, index?: number): number;
 
   clearMyFixed64List(): void;
   getMyFixed64List(): Array<number>;
-  setMyFixed64List(value: Array<number>): void;
+  setMyFixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed64(value: number, index?: number): number;
 
   clearMySfixed32List(): void;
   getMySfixed32List(): Array<number>;
-  setMySfixed32List(value: Array<number>): void;
+  setMySfixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed32(value: number, index?: number): number;
 
   clearMySfixed64List(): void;
   getMySfixed64List(): Array<number>;
-  setMySfixed64List(value: Array<number>): void;
+  setMySfixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed64(value: number, index?: number): number;
 
   clearMyBoolList(): void;
   getMyBoolList(): Array<boolean>;
-  setMyBoolList(value: Array<boolean>): void;
+  setMyBoolList(value: Array<boolean>): RepeatedPrimitiveMessage;
   addMyBool(value: boolean, index?: number): boolean;
 
   clearMyStringList(): void;
   getMyStringList(): Array<string>;
-  setMyStringList(value: Array<string>): void;
+  setMyStringList(value: Array<string>): RepeatedPrimitiveMessage;
   addMyString(value: string, index?: number): string;
 
   clearMyBytesList(): void;
   getMyBytesList(): Array<Uint8Array | string>;
   getMyBytesList_asU8(): Array<Uint8Array>;
   getMyBytesList_asB64(): Array<string>;
-  setMyBytesList(value: Array<Uint8Array | string>): void;
+  setMyBytesList(value: Array<Uint8Array | string>): RepeatedPrimitiveMessage;
   addMyBytes(value: Uint8Array | string, index?: number): Uint8Array | string;
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-js-node/proto/examplecom/reserved_words_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/reserved_words_pb.d.ts
@@ -5,178 +5,178 @@ import * as jspb from "google-protobuf";
 
 export class ReservedWordsMessage extends jspb.Message {
   getAbstract(): string;
-  setAbstract(value: string): void;
+  setAbstract(value: string): ReservedWordsMessage;
 
   getBoolean(): string;
-  setBoolean(value: string): void;
+  setBoolean(value: string): ReservedWordsMessage;
 
   getBreak(): string;
-  setBreak(value: string): void;
+  setBreak(value: string): ReservedWordsMessage;
 
   getByte(): string;
-  setByte(value: string): void;
+  setByte(value: string): ReservedWordsMessage;
 
   getCase(): string;
-  setCase(value: string): void;
+  setCase(value: string): ReservedWordsMessage;
 
   getCatch(): string;
-  setCatch(value: string): void;
+  setCatch(value: string): ReservedWordsMessage;
 
   getChar(): string;
-  setChar(value: string): void;
+  setChar(value: string): ReservedWordsMessage;
 
   getClass(): string;
-  setClass(value: string): void;
+  setClass(value: string): ReservedWordsMessage;
 
   getConst(): string;
-  setConst(value: string): void;
+  setConst(value: string): ReservedWordsMessage;
 
   getContinue(): string;
-  setContinue(value: string): void;
+  setContinue(value: string): ReservedWordsMessage;
 
   getDebugger(): string;
-  setDebugger(value: string): void;
+  setDebugger(value: string): ReservedWordsMessage;
 
   getDefault(): string;
-  setDefault(value: string): void;
+  setDefault(value: string): ReservedWordsMessage;
 
   getDelete(): string;
-  setDelete(value: string): void;
+  setDelete(value: string): ReservedWordsMessage;
 
   getDo(): string;
-  setDo(value: string): void;
+  setDo(value: string): ReservedWordsMessage;
 
   getDouble(): string;
-  setDouble(value: string): void;
+  setDouble(value: string): ReservedWordsMessage;
 
   getElse(): string;
-  setElse(value: string): void;
+  setElse(value: string): ReservedWordsMessage;
 
   getEnum(): string;
-  setEnum(value: string): void;
+  setEnum(value: string): ReservedWordsMessage;
 
   getExport(): string;
-  setExport(value: string): void;
+  setExport(value: string): ReservedWordsMessage;
 
   getExtends(): string;
-  setExtends(value: string): void;
+  setExtends(value: string): ReservedWordsMessage;
 
   getFalse(): string;
-  setFalse(value: string): void;
+  setFalse(value: string): ReservedWordsMessage;
 
   getFinal(): string;
-  setFinal(value: string): void;
+  setFinal(value: string): ReservedWordsMessage;
 
   getFinally(): string;
-  setFinally(value: string): void;
+  setFinally(value: string): ReservedWordsMessage;
 
   getFloat(): string;
-  setFloat(value: string): void;
+  setFloat(value: string): ReservedWordsMessage;
 
   getFor(): string;
-  setFor(value: string): void;
+  setFor(value: string): ReservedWordsMessage;
 
   getFunction(): string;
-  setFunction(value: string): void;
+  setFunction(value: string): ReservedWordsMessage;
 
   getGoto(): string;
-  setGoto(value: string): void;
+  setGoto(value: string): ReservedWordsMessage;
 
   getIf(): string;
-  setIf(value: string): void;
+  setIf(value: string): ReservedWordsMessage;
 
   getImplements(): string;
-  setImplements(value: string): void;
+  setImplements(value: string): ReservedWordsMessage;
 
   getImport(): string;
-  setImport(value: string): void;
+  setImport(value: string): ReservedWordsMessage;
 
   getIn(): string;
-  setIn(value: string): void;
+  setIn(value: string): ReservedWordsMessage;
 
   getInstanceof(): string;
-  setInstanceof(value: string): void;
+  setInstanceof(value: string): ReservedWordsMessage;
 
   getInt(): string;
-  setInt(value: string): void;
+  setInt(value: string): ReservedWordsMessage;
 
   getInterface(): string;
-  setInterface(value: string): void;
+  setInterface(value: string): ReservedWordsMessage;
 
   getLong(): string;
-  setLong(value: string): void;
+  setLong(value: string): ReservedWordsMessage;
 
   getNative(): string;
-  setNative(value: string): void;
+  setNative(value: string): ReservedWordsMessage;
 
   getNew(): string;
-  setNew(value: string): void;
+  setNew(value: string): ReservedWordsMessage;
 
   getNull(): string;
-  setNull(value: string): void;
+  setNull(value: string): ReservedWordsMessage;
 
   getPackage(): string;
-  setPackage(value: string): void;
+  setPackage(value: string): ReservedWordsMessage;
 
   getPrivate(): string;
-  setPrivate(value: string): void;
+  setPrivate(value: string): ReservedWordsMessage;
 
   getProtected(): string;
-  setProtected(value: string): void;
+  setProtected(value: string): ReservedWordsMessage;
 
   getPublic(): string;
-  setPublic(value: string): void;
+  setPublic(value: string): ReservedWordsMessage;
 
   getReturn(): string;
-  setReturn(value: string): void;
+  setReturn(value: string): ReservedWordsMessage;
 
   getShort(): string;
-  setShort(value: string): void;
+  setShort(value: string): ReservedWordsMessage;
 
   getStatic(): string;
-  setStatic(value: string): void;
+  setStatic(value: string): ReservedWordsMessage;
 
   getSuper(): string;
-  setSuper(value: string): void;
+  setSuper(value: string): ReservedWordsMessage;
 
   getSwitch(): string;
-  setSwitch(value: string): void;
+  setSwitch(value: string): ReservedWordsMessage;
 
   getSynchronized(): string;
-  setSynchronized(value: string): void;
+  setSynchronized(value: string): ReservedWordsMessage;
 
   getThis(): string;
-  setThis(value: string): void;
+  setThis(value: string): ReservedWordsMessage;
 
   getThrow(): string;
-  setThrow(value: string): void;
+  setThrow(value: string): ReservedWordsMessage;
 
   getThrows(): string;
-  setThrows(value: string): void;
+  setThrows(value: string): ReservedWordsMessage;
 
   getTransient(): string;
-  setTransient(value: string): void;
+  setTransient(value: string): ReservedWordsMessage;
 
   getTry(): string;
-  setTry(value: string): void;
+  setTry(value: string): ReservedWordsMessage;
 
   getTypeof(): string;
-  setTypeof(value: string): void;
+  setTypeof(value: string): ReservedWordsMessage;
 
   getVar(): string;
-  setVar(value: string): void;
+  setVar(value: string): ReservedWordsMessage;
 
   getVoid(): string;
-  setVoid(value: string): void;
+  setVoid(value: string): ReservedWordsMessage;
 
   getVolatile(): string;
-  setVolatile(value: string): void;
+  setVolatile(value: string): ReservedWordsMessage;
 
   getWhile(): string;
-  setWhile(value: string): void;
+  setWhile(value: string): ReservedWordsMessage;
 
   getWith(): string;
-  setWith(value: string): void;
+  setWith(value: string): ReservedWordsMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ReservedWordsMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/simple_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/simple_pb.d.ts
@@ -17,75 +17,75 @@ import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wr
 
 export class MySimple extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): MySimple;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): MySimple;
 
   clearSomeLabelsList(): void;
   getSomeLabelsList(): Array<string>;
-  setSomeLabelsList(value: Array<string>): void;
+  setSomeLabelsList(value: Array<string>): MySimple;
   addSomeLabels(value: string, index?: number): string;
 
   hasSomeCodeGeneratorRequest(): boolean;
   clearSomeCodeGeneratorRequest(): void;
   getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): MySimple;
 
   hasSomeAny(): boolean;
   clearSomeAny(): void;
   getSomeAny(): google_protobuf_any_pb.Any | undefined;
-  setSomeAny(value?: google_protobuf_any_pb.Any): void;
+  setSomeAny(value?: google_protobuf_any_pb.Any): MySimple;
 
   hasSomeMethod(): boolean;
   clearSomeMethod(): void;
   getSomeMethod(): google_protobuf_api_pb.Method | undefined;
-  setSomeMethod(value?: google_protobuf_api_pb.Method): void;
+  setSomeMethod(value?: google_protobuf_api_pb.Method): MySimple;
 
   hasSomeGeneratedCodeInfo(): boolean;
   clearSomeGeneratedCodeInfo(): void;
   getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): MySimple;
 
   hasSomeDuration(): boolean;
   clearSomeDuration(): void;
   getSomeDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setSomeDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setSomeDuration(value?: google_protobuf_duration_pb.Duration): MySimple;
 
   hasSomeEmpty(): boolean;
   clearSomeEmpty(): void;
   getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): MySimple;
 
   hasSomeFieldMask(): boolean;
   clearSomeFieldMask(): void;
   getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): MySimple;
 
   hasSomeSourceContext(): boolean;
   clearSomeSourceContext(): void;
   getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): MySimple;
 
   hasSomeStruct(): boolean;
   clearSomeStruct(): void;
   getSomeStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setSomeStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setSomeStruct(value?: google_protobuf_struct_pb.Struct): MySimple;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): MySimple;
 
   hasSomeType(): boolean;
   clearSomeType(): void;
   getSomeType(): google_protobuf_type_pb.Type | undefined;
-  setSomeType(value?: google_protobuf_type_pb.Type): void;
+  setSomeType(value?: google_protobuf_type_pb.Type): MySimple;
 
   hasSomeDoubleValue(): boolean;
   clearSomeDoubleValue(): void;
   getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): MySimple;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MySimple.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/simple_service_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/simple_service_pb.d.ts
@@ -8,12 +8,12 @@ import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/t
 
 export class UnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): UnaryRequest;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): UnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UnaryRequest.AsObject;
@@ -50,7 +50,7 @@ export namespace UnaryResponse {
 
 export class StreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): StreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): StreamRequest.AsObject;

--- a/examples/generated-grpc-js-node/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/simplevalue_pb.d.ts
@@ -5,40 +5,40 @@ import * as jspb from "google-protobuf";
 
 export class SimpleValue extends jspb.Message {
   getFirstField(): string;
-  setFirstField(value: string): void;
+  setFirstField(value: string): SimpleValue;
 
   getSecondField(): number;
-  setSecondField(value: number): void;
+  setSecondField(value: number): SimpleValue;
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
   getNumberValue(): number;
-  setNumberValue(value: number): void;
+  setNumberValue(value: number): SimpleValue;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
   getStringValue(): string;
-  setStringValue(value: string): void;
+  setStringValue(value: string): SimpleValue;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
   getBoolValue(): boolean;
-  setBoolValue(value: boolean): void;
+  setBoolValue(value: boolean): SimpleValue;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
   getNumber2Value(): number;
-  setNumber2Value(value: number): void;
+  setNumber2Value(value: number): SimpleValue;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
   getString2Value(): string;
-  setString2Value(value: string): void;
+  setString2Value(value: string): SimpleValue;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
   getBool2Value(): boolean;
-  setBool2Value(value: boolean): void;
+  setBool2Value(value: boolean): SimpleValue;
 
   getKindCase(): SimpleValue.KindCase;
   getAnotherCase(): SimpleValue.AnotherCase;

--- a/examples/generated-grpc-js-node/proto/examplecom/well_known_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/examplecom/well_known_message_pb.d.ts
@@ -19,62 +19,62 @@ export class WellKnownMessage extends jspb.Message {
   hasMyCodeGeneratorRequest(): boolean;
   clearMyCodeGeneratorRequest(): void;
   getMyCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): WellKnownMessage;
 
   hasMyAny(): boolean;
   clearMyAny(): void;
   getMyAny(): google_protobuf_any_pb.Any | undefined;
-  setMyAny(value?: google_protobuf_any_pb.Any): void;
+  setMyAny(value?: google_protobuf_any_pb.Any): WellKnownMessage;
 
   hasMyMethod(): boolean;
   clearMyMethod(): void;
   getMyMethod(): google_protobuf_api_pb.Method | undefined;
-  setMyMethod(value?: google_protobuf_api_pb.Method): void;
+  setMyMethod(value?: google_protobuf_api_pb.Method): WellKnownMessage;
 
   hasMyGeneratedCodeInfo(): boolean;
   clearMyGeneratedCodeInfo(): void;
   getMyGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): WellKnownMessage;
 
   hasMyDuration(): boolean;
   clearMyDuration(): void;
   getMyDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setMyDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setMyDuration(value?: google_protobuf_duration_pb.Duration): WellKnownMessage;
 
   hasMyEmpty(): boolean;
   clearMyEmpty(): void;
   getMyEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setMyEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setMyEmpty(value?: google_protobuf_empty_pb.Empty): WellKnownMessage;
 
   hasMyFieldMask(): boolean;
   clearMyFieldMask(): void;
   getMyFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): WellKnownMessage;
 
   hasMySourceContext(): boolean;
   clearMySourceContext(): void;
   getMySourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): WellKnownMessage;
 
   hasMyStruct(): boolean;
   clearMyStruct(): void;
   getMyStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setMyStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setMyStruct(value?: google_protobuf_struct_pb.Struct): WellKnownMessage;
 
   hasMyTimestamp(): boolean;
   clearMyTimestamp(): void;
   getMyTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): WellKnownMessage;
 
   hasMyType(): boolean;
   clearMyType(): void;
   getMyType(): google_protobuf_type_pb.Type | undefined;
-  setMyType(value?: google_protobuf_type_pb.Type): void;
+  setMyType(value?: google_protobuf_type_pb.Type): WellKnownMessage;
 
   hasMyDoubleValue(): boolean;
   clearMyDoubleValue(): void;
   getMyDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): WellKnownMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): WellKnownMessage.AsObject;

--- a/examples/generated-grpc-js-node/proto/orphan_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/orphan_pb.d.ts
@@ -24,13 +24,13 @@ export namespace OrphanMapMessage {
 
 export class OrphanMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OrphanMessage;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): OrphanMessage;
 
   getMyEnum(): OrphanEnumMap[keyof OrphanEnumMap];
-  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): void;
+  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): OrphanMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanMessage.AsObject;
@@ -52,7 +52,7 @@ export namespace OrphanMessage {
 
 export class OrphanUnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): OrphanUnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanUnaryRequest.AsObject;
@@ -72,7 +72,7 @@ export namespace OrphanUnaryRequest {
 
 export class OrphanStreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): OrphanStreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanStreamRequest.AsObject;

--- a/examples/generated-grpc-js-node/proto/othercom/external_child_message_pb.d.ts
+++ b/examples/generated-grpc-js-node/proto/othercom/external_child_message_pb.d.ts
@@ -5,7 +5,7 @@ import * as jspb from "google-protobuf";
 
 export class ExternalChildMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExternalChildMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/annotations_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/annotations_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class AnnotatedMessage extends jspb.Message {
   getMyunit64(): string;
-  setMyunit64(value: string): void;
+  setMyunit64(value: string): AnnotatedMessage;
 
   getMyint64(): string;
-  setMyint64(value: string): void;
+  setMyint64(value: string): AnnotatedMessage;
 
   getMyfixed64(): string;
-  setMyfixed64(value: string): void;
+  setMyfixed64(value: string): AnnotatedMessage;
 
   getMysint64(): string;
-  setMysint64(value: string): void;
+  setMysint64(value: string): AnnotatedMessage;
 
   getMysfixed64(): string;
-  setMysfixed64(value: string): void;
+  setMysfixed64(value: string): AnnotatedMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AnnotatedMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/casing_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/casing_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class CasingMessage extends jspb.Message {
   getTitlecase(): string;
-  setTitlecase(value: string): void;
+  setTitlecase(value: string): CasingMessage;
 
   getCamelcase(): string;
-  setCamelcase(value: string): void;
+  setCamelcase(value: string): CasingMessage;
 
   getSnakeCase(): string;
-  setSnakeCase(value: string): void;
+  setSnakeCase(value: string): CasingMessage;
 
   getLeadingunderscorecamelcase(): string;
-  setLeadingunderscorecamelcase(value: string): void;
+  setLeadingunderscorecamelcase(value: string): CasingMessage;
 
   getLeadingunderscoretitlecase(): string;
-  setLeadingunderscoretitlecase(value: string): void;
+  setLeadingunderscoretitlecase(value: string): CasingMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CasingMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/enum_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/enum_message_pb.d.ts
@@ -6,19 +6,19 @@ import * as proto_othercom_external_enum_pb from "../../proto/othercom/external_
 
 export class EnumMessage extends jspb.Message {
   getInternalEnum(): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
-  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): void;
+  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): EnumMessage;
 
   clearInternalEnumsList(): void;
   getInternalEnumsList(): Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>;
-  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): void;
+  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): EnumMessage;
   addInternalEnums(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap], index?: number): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
 
   getExternalEnum(): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
-  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): void;
+  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): EnumMessage;
 
   clearExternalEnumsList(): void;
   getExternalEnumsList(): Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>;
-  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): void;
+  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): EnumMessage;
   addExternalEnums(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap], index?: number): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-node/proto/examplecom/extensions_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/extensions_pb.d.ts
@@ -7,7 +7,7 @@ export class ExtensionMessage extends jspb.Message {
   hasMyExtensionString(): boolean;
   clearMyExtensionString(): void;
   getMyExtensionString(): string | undefined;
-  setMyExtensionString(value: string): void;
+  setMyExtensionString(value: string): ExtensionMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExtensionMessage.AsObject;
@@ -29,7 +29,7 @@ export class MyBase extends jspb.Message {
   hasMyBaseString(): boolean;
   clearMyBaseString(): void;
   getMyBaseString(): string | undefined;
-  setMyBaseString(value: string): void;
+  setMyBaseString(value: string): MyBase;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MyBase.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/getter_name_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/getter_name_pb.d.ts
@@ -7,14 +7,14 @@ export class GetterNameConflictMessage extends jspb.Message {
   hasExtension$(): boolean;
   clearExtension$(): void;
   getExtension$(): string | undefined;
-  setExtension$(value: string): void;
+  setExtension$(value: string): GetterNameConflictMessage;
 
   hasJsPbMessageId$(): boolean;
   clearJsPbMessageId$(): void;
   getJsPbMessageId$(): Uint8Array | string;
   getJsPbMessageId_asU8(): Uint8Array;
   getJsPbMessageId_asB64(): string;
-  setJsPbMessageId$(value: Uint8Array | string): void;
+  setJsPbMessageId$(value: Uint8Array | string): GetterNameConflictMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetterNameConflictMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/map_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/map_message_pb.d.ts
@@ -37,7 +37,7 @@ export namespace MapMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/oneof_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/oneof_message_pb.d.ts
@@ -8,22 +8,22 @@ export class OneOfMessage extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): OneOfMessage.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): void;
+  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): OneOfMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): OneOfMessage;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OneOfMessage;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): OneOfMessage;
 
   getGroupCase(): OneOfMessage.GroupCase;
   serializeBinary(): Uint8Array;
@@ -46,7 +46,7 @@ export namespace OneOfMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
@@ -77,12 +77,12 @@ export class CamelCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): CamelCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): CamelCasedOneOfMessage;
 
   getCamelcasedmessageCase(): CamelCasedOneOfMessage.CamelcasedmessageCase;
   serializeBinary(): Uint8Array;
@@ -112,12 +112,12 @@ export class SnakeCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): SnakeCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): SnakeCasedOneOfMessage;
 
   getSnakeCasedMessageCase(): SnakeCasedOneOfMessage.SnakeCasedMessageCase;
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-node/proto/examplecom/parent_message_v2_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/parent_message_v2_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV2 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV2.InternalChildMessage;
-  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV2.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV2.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): ParentMessageV2;
   addInternalChildren(value?: ParentMessageV2.InternalChildMessage, index?: number): ParentMessageV2.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV2;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -59,7 +59,7 @@ export namespace ParentMessageV2 {
     hasMyString(): boolean;
     clearMyString(): void;
     getMyString(): string | undefined;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/parent_message_v3_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV3 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): ParentMessageV3;
   addInternalChildren(value?: ParentMessageV3.InternalChildMessage, index?: number): ParentMessageV3.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV3;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -57,7 +57,7 @@ export namespace ParentMessageV3 {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/primitive_message_v2_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/primitive_message_v2_pb.d.ts
@@ -7,161 +7,161 @@ export class PrimitiveMessageV2 extends jspb.Message {
   hasMyDouble(): boolean;
   clearMyDouble(): void;
   getMyDouble(): number | undefined;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV2;
 
   hasMyFloat(): boolean;
   clearMyFloat(): void;
   getMyFloat(): number | undefined;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV2;
 
   hasMyInt32(): boolean;
   clearMyInt32(): void;
   getMyInt32(): number | undefined;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV2;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number | undefined;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV2;
 
   hasMyUint32(): boolean;
   clearMyUint32(): void;
   getMyUint32(): number | undefined;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV2;
 
   hasMyUint64(): boolean;
   clearMyUint64(): void;
   getMyUint64(): number | undefined;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV2;
 
   hasMySint32(): boolean;
   clearMySint32(): void;
   getMySint32(): number | undefined;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV2;
 
   hasMySint64(): boolean;
   clearMySint64(): void;
   getMySint64(): number | undefined;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV2;
 
   hasMyFixed32(): boolean;
   clearMyFixed32(): void;
   getMyFixed32(): number | undefined;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV2;
 
   hasMyFixed64(): boolean;
   clearMyFixed64(): void;
   getMyFixed64(): number | undefined;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV2;
 
   hasMySfixed32(): boolean;
   clearMySfixed32(): void;
   getMySfixed32(): number | undefined;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV2;
 
   hasMySfixed64(): boolean;
   clearMySfixed64(): void;
   getMySfixed64(): number | undefined;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV2;
 
   hasMyBool(): boolean;
   clearMyBool(): void;
   getMyBool(): boolean | undefined;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV2;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string | undefined;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV2;
 
   hasMyBytes(): boolean;
   clearMyBytes(): void;
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number | undefined;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV2;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number | undefined;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV2;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number | undefined;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV2;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number | undefined;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV2;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number | undefined;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV2;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number | undefined;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV2;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number | undefined;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV2;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number | undefined;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV2;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number | undefined;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV2;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number | undefined;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV2;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number | undefined;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV2;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number | undefined;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV2;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean | undefined;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV2;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string | undefined;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV2;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number | undefined;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV2;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV2.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -5,136 +5,136 @@ import * as jspb from "google-protobuf";
 
 export class PrimitiveMessageV3 extends jspb.Message {
   getMyDouble(): number;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV3;
 
   getMyFloat(): number;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV3;
 
   getMyInt32(): number;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV3;
 
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV3;
 
   getMyUint32(): number;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV3;
 
   getMyUint64(): number;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV3;
 
   getMySint32(): number;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV3;
 
   getMySint64(): number;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV3;
 
   getMyFixed32(): number;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV3;
 
   getMyFixed64(): number;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV3;
 
   getMySfixed32(): number;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV3;
 
   getMySfixed64(): number;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV3;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV3;
 
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV3;
 
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   getMyNumber(): number;
-  setMyNumber(value: number): void;
+  setMyNumber(value: number): PrimitiveMessageV3;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV3;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV3;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV3;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV3;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV3;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV3;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV3;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV3;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV3;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV3;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV3;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV3;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV3;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV3;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV3;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/repeated_primitive_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/repeated_primitive_message_pb.d.ts
@@ -6,79 +6,79 @@ import * as jspb from "google-protobuf";
 export class RepeatedPrimitiveMessage extends jspb.Message {
   clearMyDoubleList(): void;
   getMyDoubleList(): Array<number>;
-  setMyDoubleList(value: Array<number>): void;
+  setMyDoubleList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyDouble(value: number, index?: number): number;
 
   clearMyFloatList(): void;
   getMyFloatList(): Array<number>;
-  setMyFloatList(value: Array<number>): void;
+  setMyFloatList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFloat(value: number, index?: number): number;
 
   clearMyInt32List(): void;
   getMyInt32List(): Array<number>;
-  setMyInt32List(value: Array<number>): void;
+  setMyInt32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt32(value: number, index?: number): number;
 
   clearMyInt64List(): void;
   getMyInt64List(): Array<number>;
-  setMyInt64List(value: Array<number>): void;
+  setMyInt64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt64(value: number, index?: number): number;
 
   clearMyUint32List(): void;
   getMyUint32List(): Array<number>;
-  setMyUint32List(value: Array<number>): void;
+  setMyUint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint32(value: number, index?: number): number;
 
   clearMyUint64List(): void;
   getMyUint64List(): Array<number>;
-  setMyUint64List(value: Array<number>): void;
+  setMyUint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint64(value: number, index?: number): number;
 
   clearMySint32List(): void;
   getMySint32List(): Array<number>;
-  setMySint32List(value: Array<number>): void;
+  setMySint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint32(value: number, index?: number): number;
 
   clearMySint64List(): void;
   getMySint64List(): Array<number>;
-  setMySint64List(value: Array<number>): void;
+  setMySint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint64(value: number, index?: number): number;
 
   clearMyFixed32List(): void;
   getMyFixed32List(): Array<number>;
-  setMyFixed32List(value: Array<number>): void;
+  setMyFixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed32(value: number, index?: number): number;
 
   clearMyFixed64List(): void;
   getMyFixed64List(): Array<number>;
-  setMyFixed64List(value: Array<number>): void;
+  setMyFixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed64(value: number, index?: number): number;
 
   clearMySfixed32List(): void;
   getMySfixed32List(): Array<number>;
-  setMySfixed32List(value: Array<number>): void;
+  setMySfixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed32(value: number, index?: number): number;
 
   clearMySfixed64List(): void;
   getMySfixed64List(): Array<number>;
-  setMySfixed64List(value: Array<number>): void;
+  setMySfixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed64(value: number, index?: number): number;
 
   clearMyBoolList(): void;
   getMyBoolList(): Array<boolean>;
-  setMyBoolList(value: Array<boolean>): void;
+  setMyBoolList(value: Array<boolean>): RepeatedPrimitiveMessage;
   addMyBool(value: boolean, index?: number): boolean;
 
   clearMyStringList(): void;
   getMyStringList(): Array<string>;
-  setMyStringList(value: Array<string>): void;
+  setMyStringList(value: Array<string>): RepeatedPrimitiveMessage;
   addMyString(value: string, index?: number): string;
 
   clearMyBytesList(): void;
   getMyBytesList(): Array<Uint8Array | string>;
   getMyBytesList_asU8(): Array<Uint8Array>;
   getMyBytesList_asB64(): Array<string>;
-  setMyBytesList(value: Array<Uint8Array | string>): void;
+  setMyBytesList(value: Array<Uint8Array | string>): RepeatedPrimitiveMessage;
   addMyBytes(value: Uint8Array | string, index?: number): Uint8Array | string;
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-node/proto/examplecom/reserved_words_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/reserved_words_pb.d.ts
@@ -5,178 +5,178 @@ import * as jspb from "google-protobuf";
 
 export class ReservedWordsMessage extends jspb.Message {
   getAbstract(): string;
-  setAbstract(value: string): void;
+  setAbstract(value: string): ReservedWordsMessage;
 
   getBoolean(): string;
-  setBoolean(value: string): void;
+  setBoolean(value: string): ReservedWordsMessage;
 
   getBreak(): string;
-  setBreak(value: string): void;
+  setBreak(value: string): ReservedWordsMessage;
 
   getByte(): string;
-  setByte(value: string): void;
+  setByte(value: string): ReservedWordsMessage;
 
   getCase(): string;
-  setCase(value: string): void;
+  setCase(value: string): ReservedWordsMessage;
 
   getCatch(): string;
-  setCatch(value: string): void;
+  setCatch(value: string): ReservedWordsMessage;
 
   getChar(): string;
-  setChar(value: string): void;
+  setChar(value: string): ReservedWordsMessage;
 
   getClass(): string;
-  setClass(value: string): void;
+  setClass(value: string): ReservedWordsMessage;
 
   getConst(): string;
-  setConst(value: string): void;
+  setConst(value: string): ReservedWordsMessage;
 
   getContinue(): string;
-  setContinue(value: string): void;
+  setContinue(value: string): ReservedWordsMessage;
 
   getDebugger(): string;
-  setDebugger(value: string): void;
+  setDebugger(value: string): ReservedWordsMessage;
 
   getDefault(): string;
-  setDefault(value: string): void;
+  setDefault(value: string): ReservedWordsMessage;
 
   getDelete(): string;
-  setDelete(value: string): void;
+  setDelete(value: string): ReservedWordsMessage;
 
   getDo(): string;
-  setDo(value: string): void;
+  setDo(value: string): ReservedWordsMessage;
 
   getDouble(): string;
-  setDouble(value: string): void;
+  setDouble(value: string): ReservedWordsMessage;
 
   getElse(): string;
-  setElse(value: string): void;
+  setElse(value: string): ReservedWordsMessage;
 
   getEnum(): string;
-  setEnum(value: string): void;
+  setEnum(value: string): ReservedWordsMessage;
 
   getExport(): string;
-  setExport(value: string): void;
+  setExport(value: string): ReservedWordsMessage;
 
   getExtends(): string;
-  setExtends(value: string): void;
+  setExtends(value: string): ReservedWordsMessage;
 
   getFalse(): string;
-  setFalse(value: string): void;
+  setFalse(value: string): ReservedWordsMessage;
 
   getFinal(): string;
-  setFinal(value: string): void;
+  setFinal(value: string): ReservedWordsMessage;
 
   getFinally(): string;
-  setFinally(value: string): void;
+  setFinally(value: string): ReservedWordsMessage;
 
   getFloat(): string;
-  setFloat(value: string): void;
+  setFloat(value: string): ReservedWordsMessage;
 
   getFor(): string;
-  setFor(value: string): void;
+  setFor(value: string): ReservedWordsMessage;
 
   getFunction(): string;
-  setFunction(value: string): void;
+  setFunction(value: string): ReservedWordsMessage;
 
   getGoto(): string;
-  setGoto(value: string): void;
+  setGoto(value: string): ReservedWordsMessage;
 
   getIf(): string;
-  setIf(value: string): void;
+  setIf(value: string): ReservedWordsMessage;
 
   getImplements(): string;
-  setImplements(value: string): void;
+  setImplements(value: string): ReservedWordsMessage;
 
   getImport(): string;
-  setImport(value: string): void;
+  setImport(value: string): ReservedWordsMessage;
 
   getIn(): string;
-  setIn(value: string): void;
+  setIn(value: string): ReservedWordsMessage;
 
   getInstanceof(): string;
-  setInstanceof(value: string): void;
+  setInstanceof(value: string): ReservedWordsMessage;
 
   getInt(): string;
-  setInt(value: string): void;
+  setInt(value: string): ReservedWordsMessage;
 
   getInterface(): string;
-  setInterface(value: string): void;
+  setInterface(value: string): ReservedWordsMessage;
 
   getLong(): string;
-  setLong(value: string): void;
+  setLong(value: string): ReservedWordsMessage;
 
   getNative(): string;
-  setNative(value: string): void;
+  setNative(value: string): ReservedWordsMessage;
 
   getNew(): string;
-  setNew(value: string): void;
+  setNew(value: string): ReservedWordsMessage;
 
   getNull(): string;
-  setNull(value: string): void;
+  setNull(value: string): ReservedWordsMessage;
 
   getPackage(): string;
-  setPackage(value: string): void;
+  setPackage(value: string): ReservedWordsMessage;
 
   getPrivate(): string;
-  setPrivate(value: string): void;
+  setPrivate(value: string): ReservedWordsMessage;
 
   getProtected(): string;
-  setProtected(value: string): void;
+  setProtected(value: string): ReservedWordsMessage;
 
   getPublic(): string;
-  setPublic(value: string): void;
+  setPublic(value: string): ReservedWordsMessage;
 
   getReturn(): string;
-  setReturn(value: string): void;
+  setReturn(value: string): ReservedWordsMessage;
 
   getShort(): string;
-  setShort(value: string): void;
+  setShort(value: string): ReservedWordsMessage;
 
   getStatic(): string;
-  setStatic(value: string): void;
+  setStatic(value: string): ReservedWordsMessage;
 
   getSuper(): string;
-  setSuper(value: string): void;
+  setSuper(value: string): ReservedWordsMessage;
 
   getSwitch(): string;
-  setSwitch(value: string): void;
+  setSwitch(value: string): ReservedWordsMessage;
 
   getSynchronized(): string;
-  setSynchronized(value: string): void;
+  setSynchronized(value: string): ReservedWordsMessage;
 
   getThis(): string;
-  setThis(value: string): void;
+  setThis(value: string): ReservedWordsMessage;
 
   getThrow(): string;
-  setThrow(value: string): void;
+  setThrow(value: string): ReservedWordsMessage;
 
   getThrows(): string;
-  setThrows(value: string): void;
+  setThrows(value: string): ReservedWordsMessage;
 
   getTransient(): string;
-  setTransient(value: string): void;
+  setTransient(value: string): ReservedWordsMessage;
 
   getTry(): string;
-  setTry(value: string): void;
+  setTry(value: string): ReservedWordsMessage;
 
   getTypeof(): string;
-  setTypeof(value: string): void;
+  setTypeof(value: string): ReservedWordsMessage;
 
   getVar(): string;
-  setVar(value: string): void;
+  setVar(value: string): ReservedWordsMessage;
 
   getVoid(): string;
-  setVoid(value: string): void;
+  setVoid(value: string): ReservedWordsMessage;
 
   getVolatile(): string;
-  setVolatile(value: string): void;
+  setVolatile(value: string): ReservedWordsMessage;
 
   getWhile(): string;
-  setWhile(value: string): void;
+  setWhile(value: string): ReservedWordsMessage;
 
   getWith(): string;
-  setWith(value: string): void;
+  setWith(value: string): ReservedWordsMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ReservedWordsMessage.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/simple_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/simple_pb.d.ts
@@ -17,75 +17,75 @@ import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wr
 
 export class MySimple extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): MySimple;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): MySimple;
 
   clearSomeLabelsList(): void;
   getSomeLabelsList(): Array<string>;
-  setSomeLabelsList(value: Array<string>): void;
+  setSomeLabelsList(value: Array<string>): MySimple;
   addSomeLabels(value: string, index?: number): string;
 
   hasSomeCodeGeneratorRequest(): boolean;
   clearSomeCodeGeneratorRequest(): void;
   getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): MySimple;
 
   hasSomeAny(): boolean;
   clearSomeAny(): void;
   getSomeAny(): google_protobuf_any_pb.Any | undefined;
-  setSomeAny(value?: google_protobuf_any_pb.Any): void;
+  setSomeAny(value?: google_protobuf_any_pb.Any): MySimple;
 
   hasSomeMethod(): boolean;
   clearSomeMethod(): void;
   getSomeMethod(): google_protobuf_api_pb.Method | undefined;
-  setSomeMethod(value?: google_protobuf_api_pb.Method): void;
+  setSomeMethod(value?: google_protobuf_api_pb.Method): MySimple;
 
   hasSomeGeneratedCodeInfo(): boolean;
   clearSomeGeneratedCodeInfo(): void;
   getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): MySimple;
 
   hasSomeDuration(): boolean;
   clearSomeDuration(): void;
   getSomeDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setSomeDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setSomeDuration(value?: google_protobuf_duration_pb.Duration): MySimple;
 
   hasSomeEmpty(): boolean;
   clearSomeEmpty(): void;
   getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): MySimple;
 
   hasSomeFieldMask(): boolean;
   clearSomeFieldMask(): void;
   getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): MySimple;
 
   hasSomeSourceContext(): boolean;
   clearSomeSourceContext(): void;
   getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): MySimple;
 
   hasSomeStruct(): boolean;
   clearSomeStruct(): void;
   getSomeStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setSomeStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setSomeStruct(value?: google_protobuf_struct_pb.Struct): MySimple;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): MySimple;
 
   hasSomeType(): boolean;
   clearSomeType(): void;
   getSomeType(): google_protobuf_type_pb.Type | undefined;
-  setSomeType(value?: google_protobuf_type_pb.Type): void;
+  setSomeType(value?: google_protobuf_type_pb.Type): MySimple;
 
   hasSomeDoubleValue(): boolean;
   clearSomeDoubleValue(): void;
   getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): MySimple;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MySimple.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/simple_service_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/simple_service_pb.d.ts
@@ -8,12 +8,12 @@ import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/t
 
 export class UnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): UnaryRequest;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): UnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UnaryRequest.AsObject;
@@ -50,7 +50,7 @@ export namespace UnaryResponse {
 
 export class StreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): StreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): StreamRequest.AsObject;

--- a/examples/generated-grpc-node/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/simplevalue_pb.d.ts
@@ -5,40 +5,40 @@ import * as jspb from "google-protobuf";
 
 export class SimpleValue extends jspb.Message {
   getFirstField(): string;
-  setFirstField(value: string): void;
+  setFirstField(value: string): SimpleValue;
 
   getSecondField(): number;
-  setSecondField(value: number): void;
+  setSecondField(value: number): SimpleValue;
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
   getNumberValue(): number;
-  setNumberValue(value: number): void;
+  setNumberValue(value: number): SimpleValue;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
   getStringValue(): string;
-  setStringValue(value: string): void;
+  setStringValue(value: string): SimpleValue;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
   getBoolValue(): boolean;
-  setBoolValue(value: boolean): void;
+  setBoolValue(value: boolean): SimpleValue;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
   getNumber2Value(): number;
-  setNumber2Value(value: number): void;
+  setNumber2Value(value: number): SimpleValue;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
   getString2Value(): string;
-  setString2Value(value: string): void;
+  setString2Value(value: string): SimpleValue;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
   getBool2Value(): boolean;
-  setBool2Value(value: boolean): void;
+  setBool2Value(value: boolean): SimpleValue;
 
   getKindCase(): SimpleValue.KindCase;
   getAnotherCase(): SimpleValue.AnotherCase;

--- a/examples/generated-grpc-node/proto/examplecom/well_known_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/examplecom/well_known_message_pb.d.ts
@@ -19,62 +19,62 @@ export class WellKnownMessage extends jspb.Message {
   hasMyCodeGeneratorRequest(): boolean;
   clearMyCodeGeneratorRequest(): void;
   getMyCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): WellKnownMessage;
 
   hasMyAny(): boolean;
   clearMyAny(): void;
   getMyAny(): google_protobuf_any_pb.Any | undefined;
-  setMyAny(value?: google_protobuf_any_pb.Any): void;
+  setMyAny(value?: google_protobuf_any_pb.Any): WellKnownMessage;
 
   hasMyMethod(): boolean;
   clearMyMethod(): void;
   getMyMethod(): google_protobuf_api_pb.Method | undefined;
-  setMyMethod(value?: google_protobuf_api_pb.Method): void;
+  setMyMethod(value?: google_protobuf_api_pb.Method): WellKnownMessage;
 
   hasMyGeneratedCodeInfo(): boolean;
   clearMyGeneratedCodeInfo(): void;
   getMyGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): WellKnownMessage;
 
   hasMyDuration(): boolean;
   clearMyDuration(): void;
   getMyDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setMyDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setMyDuration(value?: google_protobuf_duration_pb.Duration): WellKnownMessage;
 
   hasMyEmpty(): boolean;
   clearMyEmpty(): void;
   getMyEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setMyEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setMyEmpty(value?: google_protobuf_empty_pb.Empty): WellKnownMessage;
 
   hasMyFieldMask(): boolean;
   clearMyFieldMask(): void;
   getMyFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): WellKnownMessage;
 
   hasMySourceContext(): boolean;
   clearMySourceContext(): void;
   getMySourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): WellKnownMessage;
 
   hasMyStruct(): boolean;
   clearMyStruct(): void;
   getMyStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setMyStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setMyStruct(value?: google_protobuf_struct_pb.Struct): WellKnownMessage;
 
   hasMyTimestamp(): boolean;
   clearMyTimestamp(): void;
   getMyTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): WellKnownMessage;
 
   hasMyType(): boolean;
   clearMyType(): void;
   getMyType(): google_protobuf_type_pb.Type | undefined;
-  setMyType(value?: google_protobuf_type_pb.Type): void;
+  setMyType(value?: google_protobuf_type_pb.Type): WellKnownMessage;
 
   hasMyDoubleValue(): boolean;
   clearMyDoubleValue(): void;
   getMyDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): WellKnownMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): WellKnownMessage.AsObject;

--- a/examples/generated-grpc-node/proto/orphan_pb.d.ts
+++ b/examples/generated-grpc-node/proto/orphan_pb.d.ts
@@ -24,13 +24,13 @@ export namespace OrphanMapMessage {
 
 export class OrphanMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OrphanMessage;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): OrphanMessage;
 
   getMyEnum(): OrphanEnumMap[keyof OrphanEnumMap];
-  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): void;
+  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): OrphanMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanMessage.AsObject;
@@ -52,7 +52,7 @@ export namespace OrphanMessage {
 
 export class OrphanUnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): OrphanUnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanUnaryRequest.AsObject;
@@ -72,7 +72,7 @@ export namespace OrphanUnaryRequest {
 
 export class OrphanStreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): OrphanStreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanStreamRequest.AsObject;

--- a/examples/generated-grpc-node/proto/othercom/external_child_message_pb.d.ts
+++ b/examples/generated-grpc-node/proto/othercom/external_child_message_pb.d.ts
@@ -5,7 +5,7 @@ import * as jspb from "google-protobuf";
 
 export class ExternalChildMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExternalChildMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/annotations_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/annotations_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class AnnotatedMessage extends jspb.Message {
   getMyunit64(): string;
-  setMyunit64(value: string): void;
+  setMyunit64(value: string): AnnotatedMessage;
 
   getMyint64(): string;
-  setMyint64(value: string): void;
+  setMyint64(value: string): AnnotatedMessage;
 
   getMyfixed64(): string;
-  setMyfixed64(value: string): void;
+  setMyfixed64(value: string): AnnotatedMessage;
 
   getMysint64(): string;
-  setMysint64(value: string): void;
+  setMysint64(value: string): AnnotatedMessage;
 
   getMysfixed64(): string;
-  setMysfixed64(value: string): void;
+  setMysfixed64(value: string): AnnotatedMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AnnotatedMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/casing_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/casing_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class CasingMessage extends jspb.Message {
   getTitlecase(): string;
-  setTitlecase(value: string): void;
+  setTitlecase(value: string): CasingMessage;
 
   getCamelcase(): string;
-  setCamelcase(value: string): void;
+  setCamelcase(value: string): CasingMessage;
 
   getSnakeCase(): string;
-  setSnakeCase(value: string): void;
+  setSnakeCase(value: string): CasingMessage;
 
   getLeadingunderscorecamelcase(): string;
-  setLeadingunderscorecamelcase(value: string): void;
+  setLeadingunderscorecamelcase(value: string): CasingMessage;
 
   getLeadingunderscoretitlecase(): string;
-  setLeadingunderscoretitlecase(value: string): void;
+  setLeadingunderscoretitlecase(value: string): CasingMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CasingMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/enum_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/enum_message_pb.d.ts
@@ -6,19 +6,19 @@ import * as proto_othercom_external_enum_pb from "../../proto/othercom/external_
 
 export class EnumMessage extends jspb.Message {
   getInternalEnum(): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
-  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): void;
+  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): EnumMessage;
 
   clearInternalEnumsList(): void;
   getInternalEnumsList(): Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>;
-  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): void;
+  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): EnumMessage;
   addInternalEnums(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap], index?: number): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
 
   getExternalEnum(): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
-  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): void;
+  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): EnumMessage;
 
   clearExternalEnumsList(): void;
   getExternalEnumsList(): Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>;
-  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): void;
+  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): EnumMessage;
   addExternalEnums(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap], index?: number): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-web/proto/examplecom/extensions_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/extensions_pb.d.ts
@@ -7,7 +7,7 @@ export class ExtensionMessage extends jspb.Message {
   hasMyExtensionString(): boolean;
   clearMyExtensionString(): void;
   getMyExtensionString(): string | undefined;
-  setMyExtensionString(value: string): void;
+  setMyExtensionString(value: string): ExtensionMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExtensionMessage.AsObject;
@@ -29,7 +29,7 @@ export class MyBase extends jspb.Message {
   hasMyBaseString(): boolean;
   clearMyBaseString(): void;
   getMyBaseString(): string | undefined;
-  setMyBaseString(value: string): void;
+  setMyBaseString(value: string): MyBase;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MyBase.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/getter_name_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/getter_name_pb.d.ts
@@ -7,14 +7,14 @@ export class GetterNameConflictMessage extends jspb.Message {
   hasExtension$(): boolean;
   clearExtension$(): void;
   getExtension$(): string | undefined;
-  setExtension$(value: string): void;
+  setExtension$(value: string): GetterNameConflictMessage;
 
   hasJsPbMessageId$(): boolean;
   clearJsPbMessageId$(): void;
   getJsPbMessageId$(): Uint8Array | string;
   getJsPbMessageId_asU8(): Uint8Array;
   getJsPbMessageId_asB64(): string;
-  setJsPbMessageId$(value: Uint8Array | string): void;
+  setJsPbMessageId$(value: Uint8Array | string): GetterNameConflictMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetterNameConflictMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/map_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/map_message_pb.d.ts
@@ -37,7 +37,7 @@ export namespace MapMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/oneof_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/oneof_message_pb.d.ts
@@ -8,22 +8,22 @@ export class OneOfMessage extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): OneOfMessage.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): void;
+  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): OneOfMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): OneOfMessage;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OneOfMessage;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): OneOfMessage;
 
   getGroupCase(): OneOfMessage.GroupCase;
   serializeBinary(): Uint8Array;
@@ -46,7 +46,7 @@ export namespace OneOfMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
@@ -77,12 +77,12 @@ export class CamelCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): CamelCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): CamelCasedOneOfMessage;
 
   getCamelcasedmessageCase(): CamelCasedOneOfMessage.CamelcasedmessageCase;
   serializeBinary(): Uint8Array;
@@ -112,12 +112,12 @@ export class SnakeCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): SnakeCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): SnakeCasedOneOfMessage;
 
   getSnakeCasedMessageCase(): SnakeCasedOneOfMessage.SnakeCasedMessageCase;
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-web/proto/examplecom/parent_message_v2_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/parent_message_v2_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV2 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV2.InternalChildMessage;
-  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV2.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV2.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): ParentMessageV2;
   addInternalChildren(value?: ParentMessageV2.InternalChildMessage, index?: number): ParentMessageV2.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV2;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -59,7 +59,7 @@ export namespace ParentMessageV2 {
     hasMyString(): boolean;
     clearMyString(): void;
     getMyString(): string | undefined;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/parent_message_v3_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV3 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): ParentMessageV3;
   addInternalChildren(value?: ParentMessageV3.InternalChildMessage, index?: number): ParentMessageV3.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV3;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -57,7 +57,7 @@ export namespace ParentMessageV3 {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/primitive_message_v2_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/primitive_message_v2_pb.d.ts
@@ -7,161 +7,161 @@ export class PrimitiveMessageV2 extends jspb.Message {
   hasMyDouble(): boolean;
   clearMyDouble(): void;
   getMyDouble(): number | undefined;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV2;
 
   hasMyFloat(): boolean;
   clearMyFloat(): void;
   getMyFloat(): number | undefined;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV2;
 
   hasMyInt32(): boolean;
   clearMyInt32(): void;
   getMyInt32(): number | undefined;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV2;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number | undefined;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV2;
 
   hasMyUint32(): boolean;
   clearMyUint32(): void;
   getMyUint32(): number | undefined;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV2;
 
   hasMyUint64(): boolean;
   clearMyUint64(): void;
   getMyUint64(): number | undefined;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV2;
 
   hasMySint32(): boolean;
   clearMySint32(): void;
   getMySint32(): number | undefined;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV2;
 
   hasMySint64(): boolean;
   clearMySint64(): void;
   getMySint64(): number | undefined;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV2;
 
   hasMyFixed32(): boolean;
   clearMyFixed32(): void;
   getMyFixed32(): number | undefined;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV2;
 
   hasMyFixed64(): boolean;
   clearMyFixed64(): void;
   getMyFixed64(): number | undefined;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV2;
 
   hasMySfixed32(): boolean;
   clearMySfixed32(): void;
   getMySfixed32(): number | undefined;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV2;
 
   hasMySfixed64(): boolean;
   clearMySfixed64(): void;
   getMySfixed64(): number | undefined;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV2;
 
   hasMyBool(): boolean;
   clearMyBool(): void;
   getMyBool(): boolean | undefined;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV2;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string | undefined;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV2;
 
   hasMyBytes(): boolean;
   clearMyBytes(): void;
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number | undefined;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV2;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number | undefined;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV2;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number | undefined;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV2;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number | undefined;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV2;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number | undefined;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV2;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number | undefined;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV2;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number | undefined;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV2;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number | undefined;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV2;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number | undefined;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV2;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number | undefined;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV2;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number | undefined;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV2;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number | undefined;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV2;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean | undefined;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV2;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string | undefined;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV2;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number | undefined;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV2;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV2.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -5,136 +5,136 @@ import * as jspb from "google-protobuf";
 
 export class PrimitiveMessageV3 extends jspb.Message {
   getMyDouble(): number;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV3;
 
   getMyFloat(): number;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV3;
 
   getMyInt32(): number;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV3;
 
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV3;
 
   getMyUint32(): number;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV3;
 
   getMyUint64(): number;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV3;
 
   getMySint32(): number;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV3;
 
   getMySint64(): number;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV3;
 
   getMyFixed32(): number;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV3;
 
   getMyFixed64(): number;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV3;
 
   getMySfixed32(): number;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV3;
 
   getMySfixed64(): number;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV3;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV3;
 
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV3;
 
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   getMyNumber(): number;
-  setMyNumber(value: number): void;
+  setMyNumber(value: number): PrimitiveMessageV3;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV3;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV3;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV3;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV3;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV3;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV3;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV3;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV3;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV3;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV3;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV3;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV3;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV3;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV3;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV3;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/repeated_primitive_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/repeated_primitive_message_pb.d.ts
@@ -6,79 +6,79 @@ import * as jspb from "google-protobuf";
 export class RepeatedPrimitiveMessage extends jspb.Message {
   clearMyDoubleList(): void;
   getMyDoubleList(): Array<number>;
-  setMyDoubleList(value: Array<number>): void;
+  setMyDoubleList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyDouble(value: number, index?: number): number;
 
   clearMyFloatList(): void;
   getMyFloatList(): Array<number>;
-  setMyFloatList(value: Array<number>): void;
+  setMyFloatList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFloat(value: number, index?: number): number;
 
   clearMyInt32List(): void;
   getMyInt32List(): Array<number>;
-  setMyInt32List(value: Array<number>): void;
+  setMyInt32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt32(value: number, index?: number): number;
 
   clearMyInt64List(): void;
   getMyInt64List(): Array<number>;
-  setMyInt64List(value: Array<number>): void;
+  setMyInt64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt64(value: number, index?: number): number;
 
   clearMyUint32List(): void;
   getMyUint32List(): Array<number>;
-  setMyUint32List(value: Array<number>): void;
+  setMyUint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint32(value: number, index?: number): number;
 
   clearMyUint64List(): void;
   getMyUint64List(): Array<number>;
-  setMyUint64List(value: Array<number>): void;
+  setMyUint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint64(value: number, index?: number): number;
 
   clearMySint32List(): void;
   getMySint32List(): Array<number>;
-  setMySint32List(value: Array<number>): void;
+  setMySint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint32(value: number, index?: number): number;
 
   clearMySint64List(): void;
   getMySint64List(): Array<number>;
-  setMySint64List(value: Array<number>): void;
+  setMySint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint64(value: number, index?: number): number;
 
   clearMyFixed32List(): void;
   getMyFixed32List(): Array<number>;
-  setMyFixed32List(value: Array<number>): void;
+  setMyFixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed32(value: number, index?: number): number;
 
   clearMyFixed64List(): void;
   getMyFixed64List(): Array<number>;
-  setMyFixed64List(value: Array<number>): void;
+  setMyFixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed64(value: number, index?: number): number;
 
   clearMySfixed32List(): void;
   getMySfixed32List(): Array<number>;
-  setMySfixed32List(value: Array<number>): void;
+  setMySfixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed32(value: number, index?: number): number;
 
   clearMySfixed64List(): void;
   getMySfixed64List(): Array<number>;
-  setMySfixed64List(value: Array<number>): void;
+  setMySfixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed64(value: number, index?: number): number;
 
   clearMyBoolList(): void;
   getMyBoolList(): Array<boolean>;
-  setMyBoolList(value: Array<boolean>): void;
+  setMyBoolList(value: Array<boolean>): RepeatedPrimitiveMessage;
   addMyBool(value: boolean, index?: number): boolean;
 
   clearMyStringList(): void;
   getMyStringList(): Array<string>;
-  setMyStringList(value: Array<string>): void;
+  setMyStringList(value: Array<string>): RepeatedPrimitiveMessage;
   addMyString(value: string, index?: number): string;
 
   clearMyBytesList(): void;
   getMyBytesList(): Array<Uint8Array | string>;
   getMyBytesList_asU8(): Array<Uint8Array>;
   getMyBytesList_asB64(): Array<string>;
-  setMyBytesList(value: Array<Uint8Array | string>): void;
+  setMyBytesList(value: Array<Uint8Array | string>): RepeatedPrimitiveMessage;
   addMyBytes(value: Uint8Array | string, index?: number): Uint8Array | string;
 
   serializeBinary(): Uint8Array;

--- a/examples/generated-grpc-web/proto/examplecom/reserved_words_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/reserved_words_pb.d.ts
@@ -5,178 +5,178 @@ import * as jspb from "google-protobuf";
 
 export class ReservedWordsMessage extends jspb.Message {
   getAbstract(): string;
-  setAbstract(value: string): void;
+  setAbstract(value: string): ReservedWordsMessage;
 
   getBoolean(): string;
-  setBoolean(value: string): void;
+  setBoolean(value: string): ReservedWordsMessage;
 
   getBreak(): string;
-  setBreak(value: string): void;
+  setBreak(value: string): ReservedWordsMessage;
 
   getByte(): string;
-  setByte(value: string): void;
+  setByte(value: string): ReservedWordsMessage;
 
   getCase(): string;
-  setCase(value: string): void;
+  setCase(value: string): ReservedWordsMessage;
 
   getCatch(): string;
-  setCatch(value: string): void;
+  setCatch(value: string): ReservedWordsMessage;
 
   getChar(): string;
-  setChar(value: string): void;
+  setChar(value: string): ReservedWordsMessage;
 
   getClass(): string;
-  setClass(value: string): void;
+  setClass(value: string): ReservedWordsMessage;
 
   getConst(): string;
-  setConst(value: string): void;
+  setConst(value: string): ReservedWordsMessage;
 
   getContinue(): string;
-  setContinue(value: string): void;
+  setContinue(value: string): ReservedWordsMessage;
 
   getDebugger(): string;
-  setDebugger(value: string): void;
+  setDebugger(value: string): ReservedWordsMessage;
 
   getDefault(): string;
-  setDefault(value: string): void;
+  setDefault(value: string): ReservedWordsMessage;
 
   getDelete(): string;
-  setDelete(value: string): void;
+  setDelete(value: string): ReservedWordsMessage;
 
   getDo(): string;
-  setDo(value: string): void;
+  setDo(value: string): ReservedWordsMessage;
 
   getDouble(): string;
-  setDouble(value: string): void;
+  setDouble(value: string): ReservedWordsMessage;
 
   getElse(): string;
-  setElse(value: string): void;
+  setElse(value: string): ReservedWordsMessage;
 
   getEnum(): string;
-  setEnum(value: string): void;
+  setEnum(value: string): ReservedWordsMessage;
 
   getExport(): string;
-  setExport(value: string): void;
+  setExport(value: string): ReservedWordsMessage;
 
   getExtends(): string;
-  setExtends(value: string): void;
+  setExtends(value: string): ReservedWordsMessage;
 
   getFalse(): string;
-  setFalse(value: string): void;
+  setFalse(value: string): ReservedWordsMessage;
 
   getFinal(): string;
-  setFinal(value: string): void;
+  setFinal(value: string): ReservedWordsMessage;
 
   getFinally(): string;
-  setFinally(value: string): void;
+  setFinally(value: string): ReservedWordsMessage;
 
   getFloat(): string;
-  setFloat(value: string): void;
+  setFloat(value: string): ReservedWordsMessage;
 
   getFor(): string;
-  setFor(value: string): void;
+  setFor(value: string): ReservedWordsMessage;
 
   getFunction(): string;
-  setFunction(value: string): void;
+  setFunction(value: string): ReservedWordsMessage;
 
   getGoto(): string;
-  setGoto(value: string): void;
+  setGoto(value: string): ReservedWordsMessage;
 
   getIf(): string;
-  setIf(value: string): void;
+  setIf(value: string): ReservedWordsMessage;
 
   getImplements(): string;
-  setImplements(value: string): void;
+  setImplements(value: string): ReservedWordsMessage;
 
   getImport(): string;
-  setImport(value: string): void;
+  setImport(value: string): ReservedWordsMessage;
 
   getIn(): string;
-  setIn(value: string): void;
+  setIn(value: string): ReservedWordsMessage;
 
   getInstanceof(): string;
-  setInstanceof(value: string): void;
+  setInstanceof(value: string): ReservedWordsMessage;
 
   getInt(): string;
-  setInt(value: string): void;
+  setInt(value: string): ReservedWordsMessage;
 
   getInterface(): string;
-  setInterface(value: string): void;
+  setInterface(value: string): ReservedWordsMessage;
 
   getLong(): string;
-  setLong(value: string): void;
+  setLong(value: string): ReservedWordsMessage;
 
   getNative(): string;
-  setNative(value: string): void;
+  setNative(value: string): ReservedWordsMessage;
 
   getNew(): string;
-  setNew(value: string): void;
+  setNew(value: string): ReservedWordsMessage;
 
   getNull(): string;
-  setNull(value: string): void;
+  setNull(value: string): ReservedWordsMessage;
 
   getPackage(): string;
-  setPackage(value: string): void;
+  setPackage(value: string): ReservedWordsMessage;
 
   getPrivate(): string;
-  setPrivate(value: string): void;
+  setPrivate(value: string): ReservedWordsMessage;
 
   getProtected(): string;
-  setProtected(value: string): void;
+  setProtected(value: string): ReservedWordsMessage;
 
   getPublic(): string;
-  setPublic(value: string): void;
+  setPublic(value: string): ReservedWordsMessage;
 
   getReturn(): string;
-  setReturn(value: string): void;
+  setReturn(value: string): ReservedWordsMessage;
 
   getShort(): string;
-  setShort(value: string): void;
+  setShort(value: string): ReservedWordsMessage;
 
   getStatic(): string;
-  setStatic(value: string): void;
+  setStatic(value: string): ReservedWordsMessage;
 
   getSuper(): string;
-  setSuper(value: string): void;
+  setSuper(value: string): ReservedWordsMessage;
 
   getSwitch(): string;
-  setSwitch(value: string): void;
+  setSwitch(value: string): ReservedWordsMessage;
 
   getSynchronized(): string;
-  setSynchronized(value: string): void;
+  setSynchronized(value: string): ReservedWordsMessage;
 
   getThis(): string;
-  setThis(value: string): void;
+  setThis(value: string): ReservedWordsMessage;
 
   getThrow(): string;
-  setThrow(value: string): void;
+  setThrow(value: string): ReservedWordsMessage;
 
   getThrows(): string;
-  setThrows(value: string): void;
+  setThrows(value: string): ReservedWordsMessage;
 
   getTransient(): string;
-  setTransient(value: string): void;
+  setTransient(value: string): ReservedWordsMessage;
 
   getTry(): string;
-  setTry(value: string): void;
+  setTry(value: string): ReservedWordsMessage;
 
   getTypeof(): string;
-  setTypeof(value: string): void;
+  setTypeof(value: string): ReservedWordsMessage;
 
   getVar(): string;
-  setVar(value: string): void;
+  setVar(value: string): ReservedWordsMessage;
 
   getVoid(): string;
-  setVoid(value: string): void;
+  setVoid(value: string): ReservedWordsMessage;
 
   getVolatile(): string;
-  setVolatile(value: string): void;
+  setVolatile(value: string): ReservedWordsMessage;
 
   getWhile(): string;
-  setWhile(value: string): void;
+  setWhile(value: string): ReservedWordsMessage;
 
   getWith(): string;
-  setWith(value: string): void;
+  setWith(value: string): ReservedWordsMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ReservedWordsMessage.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/simple_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/simple_pb.d.ts
@@ -17,75 +17,75 @@ import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wr
 
 export class MySimple extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): MySimple;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): MySimple;
 
   clearSomeLabelsList(): void;
   getSomeLabelsList(): Array<string>;
-  setSomeLabelsList(value: Array<string>): void;
+  setSomeLabelsList(value: Array<string>): MySimple;
   addSomeLabels(value: string, index?: number): string;
 
   hasSomeCodeGeneratorRequest(): boolean;
   clearSomeCodeGeneratorRequest(): void;
   getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): MySimple;
 
   hasSomeAny(): boolean;
   clearSomeAny(): void;
   getSomeAny(): google_protobuf_any_pb.Any | undefined;
-  setSomeAny(value?: google_protobuf_any_pb.Any): void;
+  setSomeAny(value?: google_protobuf_any_pb.Any): MySimple;
 
   hasSomeMethod(): boolean;
   clearSomeMethod(): void;
   getSomeMethod(): google_protobuf_api_pb.Method | undefined;
-  setSomeMethod(value?: google_protobuf_api_pb.Method): void;
+  setSomeMethod(value?: google_protobuf_api_pb.Method): MySimple;
 
   hasSomeGeneratedCodeInfo(): boolean;
   clearSomeGeneratedCodeInfo(): void;
   getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): MySimple;
 
   hasSomeDuration(): boolean;
   clearSomeDuration(): void;
   getSomeDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setSomeDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setSomeDuration(value?: google_protobuf_duration_pb.Duration): MySimple;
 
   hasSomeEmpty(): boolean;
   clearSomeEmpty(): void;
   getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): MySimple;
 
   hasSomeFieldMask(): boolean;
   clearSomeFieldMask(): void;
   getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): MySimple;
 
   hasSomeSourceContext(): boolean;
   clearSomeSourceContext(): void;
   getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): MySimple;
 
   hasSomeStruct(): boolean;
   clearSomeStruct(): void;
   getSomeStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setSomeStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setSomeStruct(value?: google_protobuf_struct_pb.Struct): MySimple;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): MySimple;
 
   hasSomeType(): boolean;
   clearSomeType(): void;
   getSomeType(): google_protobuf_type_pb.Type | undefined;
-  setSomeType(value?: google_protobuf_type_pb.Type): void;
+  setSomeType(value?: google_protobuf_type_pb.Type): MySimple;
 
   hasSomeDoubleValue(): boolean;
   clearSomeDoubleValue(): void;
   getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): MySimple;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MySimple.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/simple_service_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/simple_service_pb.d.ts
@@ -8,12 +8,12 @@ import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/t
 
 export class UnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): UnaryRequest;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): UnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UnaryRequest.AsObject;
@@ -50,7 +50,7 @@ export namespace UnaryResponse {
 
 export class StreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): StreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): StreamRequest.AsObject;

--- a/examples/generated-grpc-web/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/simplevalue_pb.d.ts
@@ -5,40 +5,40 @@ import * as jspb from "google-protobuf";
 
 export class SimpleValue extends jspb.Message {
   getFirstField(): string;
-  setFirstField(value: string): void;
+  setFirstField(value: string): SimpleValue;
 
   getSecondField(): number;
-  setSecondField(value: number): void;
+  setSecondField(value: number): SimpleValue;
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
   getNumberValue(): number;
-  setNumberValue(value: number): void;
+  setNumberValue(value: number): SimpleValue;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
   getStringValue(): string;
-  setStringValue(value: string): void;
+  setStringValue(value: string): SimpleValue;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
   getBoolValue(): boolean;
-  setBoolValue(value: boolean): void;
+  setBoolValue(value: boolean): SimpleValue;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
   getNumber2Value(): number;
-  setNumber2Value(value: number): void;
+  setNumber2Value(value: number): SimpleValue;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
   getString2Value(): string;
-  setString2Value(value: string): void;
+  setString2Value(value: string): SimpleValue;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
   getBool2Value(): boolean;
-  setBool2Value(value: boolean): void;
+  setBool2Value(value: boolean): SimpleValue;
 
   getKindCase(): SimpleValue.KindCase;
   getAnotherCase(): SimpleValue.AnotherCase;

--- a/examples/generated-grpc-web/proto/examplecom/well_known_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/examplecom/well_known_message_pb.d.ts
@@ -19,62 +19,62 @@ export class WellKnownMessage extends jspb.Message {
   hasMyCodeGeneratorRequest(): boolean;
   clearMyCodeGeneratorRequest(): void;
   getMyCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): WellKnownMessage;
 
   hasMyAny(): boolean;
   clearMyAny(): void;
   getMyAny(): google_protobuf_any_pb.Any | undefined;
-  setMyAny(value?: google_protobuf_any_pb.Any): void;
+  setMyAny(value?: google_protobuf_any_pb.Any): WellKnownMessage;
 
   hasMyMethod(): boolean;
   clearMyMethod(): void;
   getMyMethod(): google_protobuf_api_pb.Method | undefined;
-  setMyMethod(value?: google_protobuf_api_pb.Method): void;
+  setMyMethod(value?: google_protobuf_api_pb.Method): WellKnownMessage;
 
   hasMyGeneratedCodeInfo(): boolean;
   clearMyGeneratedCodeInfo(): void;
   getMyGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): WellKnownMessage;
 
   hasMyDuration(): boolean;
   clearMyDuration(): void;
   getMyDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setMyDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setMyDuration(value?: google_protobuf_duration_pb.Duration): WellKnownMessage;
 
   hasMyEmpty(): boolean;
   clearMyEmpty(): void;
   getMyEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setMyEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setMyEmpty(value?: google_protobuf_empty_pb.Empty): WellKnownMessage;
 
   hasMyFieldMask(): boolean;
   clearMyFieldMask(): void;
   getMyFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): WellKnownMessage;
 
   hasMySourceContext(): boolean;
   clearMySourceContext(): void;
   getMySourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): WellKnownMessage;
 
   hasMyStruct(): boolean;
   clearMyStruct(): void;
   getMyStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setMyStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setMyStruct(value?: google_protobuf_struct_pb.Struct): WellKnownMessage;
 
   hasMyTimestamp(): boolean;
   clearMyTimestamp(): void;
   getMyTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): WellKnownMessage;
 
   hasMyType(): boolean;
   clearMyType(): void;
   getMyType(): google_protobuf_type_pb.Type | undefined;
-  setMyType(value?: google_protobuf_type_pb.Type): void;
+  setMyType(value?: google_protobuf_type_pb.Type): WellKnownMessage;
 
   hasMyDoubleValue(): boolean;
   clearMyDoubleValue(): void;
   getMyDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): WellKnownMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): WellKnownMessage.AsObject;

--- a/examples/generated-grpc-web/proto/orphan_pb.d.ts
+++ b/examples/generated-grpc-web/proto/orphan_pb.d.ts
@@ -24,13 +24,13 @@ export namespace OrphanMapMessage {
 
 export class OrphanMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OrphanMessage;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): OrphanMessage;
 
   getMyEnum(): OrphanEnumMap[keyof OrphanEnumMap];
-  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): void;
+  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): OrphanMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanMessage.AsObject;
@@ -52,7 +52,7 @@ export namespace OrphanMessage {
 
 export class OrphanUnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): OrphanUnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanUnaryRequest.AsObject;
@@ -72,7 +72,7 @@ export namespace OrphanUnaryRequest {
 
 export class OrphanStreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): OrphanStreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanStreamRequest.AsObject;

--- a/examples/generated-grpc-web/proto/othercom/external_child_message_pb.d.ts
+++ b/examples/generated-grpc-web/proto/othercom/external_child_message_pb.d.ts
@@ -5,7 +5,7 @@ import * as jspb from "google-protobuf";
 
 export class ExternalChildMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExternalChildMessage.AsObject;

--- a/examples/generated/proto/examplecom/annotations_pb.d.ts
+++ b/examples/generated/proto/examplecom/annotations_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class AnnotatedMessage extends jspb.Message {
   getMyunit64(): string;
-  setMyunit64(value: string): void;
+  setMyunit64(value: string): AnnotatedMessage;
 
   getMyint64(): string;
-  setMyint64(value: string): void;
+  setMyint64(value: string): AnnotatedMessage;
 
   getMyfixed64(): string;
-  setMyfixed64(value: string): void;
+  setMyfixed64(value: string): AnnotatedMessage;
 
   getMysint64(): string;
-  setMysint64(value: string): void;
+  setMysint64(value: string): AnnotatedMessage;
 
   getMysfixed64(): string;
-  setMysfixed64(value: string): void;
+  setMysfixed64(value: string): AnnotatedMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AnnotatedMessage.AsObject;

--- a/examples/generated/proto/examplecom/casing_pb.d.ts
+++ b/examples/generated/proto/examplecom/casing_pb.d.ts
@@ -5,19 +5,19 @@ import * as jspb from "google-protobuf";
 
 export class CasingMessage extends jspb.Message {
   getTitlecase(): string;
-  setTitlecase(value: string): void;
+  setTitlecase(value: string): CasingMessage;
 
   getCamelcase(): string;
-  setCamelcase(value: string): void;
+  setCamelcase(value: string): CasingMessage;
 
   getSnakeCase(): string;
-  setSnakeCase(value: string): void;
+  setSnakeCase(value: string): CasingMessage;
 
   getLeadingunderscorecamelcase(): string;
-  setLeadingunderscorecamelcase(value: string): void;
+  setLeadingunderscorecamelcase(value: string): CasingMessage;
 
   getLeadingunderscoretitlecase(): string;
-  setLeadingunderscoretitlecase(value: string): void;
+  setLeadingunderscoretitlecase(value: string): CasingMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): CasingMessage.AsObject;

--- a/examples/generated/proto/examplecom/enum_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/enum_message_pb.d.ts
@@ -6,19 +6,19 @@ import * as proto_othercom_external_enum_pb from "../../proto/othercom/external_
 
 export class EnumMessage extends jspb.Message {
   getInternalEnum(): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
-  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): void;
+  setInternalEnum(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]): EnumMessage;
 
   clearInternalEnumsList(): void;
   getInternalEnumsList(): Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>;
-  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): void;
+  setInternalEnumsList(value: Array<EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap]>): EnumMessage;
   addInternalEnums(value: EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap], index?: number): EnumMessage.InternalEnumMap[keyof EnumMessage.InternalEnumMap];
 
   getExternalEnum(): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
-  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): void;
+  setExternalEnum(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]): EnumMessage;
 
   clearExternalEnumsList(): void;
   getExternalEnumsList(): Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>;
-  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): void;
+  setExternalEnumsList(value: Array<proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap]>): EnumMessage;
   addExternalEnums(value: proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap], index?: number): proto_othercom_external_enum_pb.ExternalEnumMap[keyof proto_othercom_external_enum_pb.ExternalEnumMap];
 
   serializeBinary(): Uint8Array;

--- a/examples/generated/proto/examplecom/extensions_pb.d.ts
+++ b/examples/generated/proto/examplecom/extensions_pb.d.ts
@@ -7,7 +7,7 @@ export class ExtensionMessage extends jspb.Message {
   hasMyExtensionString(): boolean;
   clearMyExtensionString(): void;
   getMyExtensionString(): string | undefined;
-  setMyExtensionString(value: string): void;
+  setMyExtensionString(value: string): ExtensionMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExtensionMessage.AsObject;
@@ -29,7 +29,7 @@ export class MyBase extends jspb.Message {
   hasMyBaseString(): boolean;
   clearMyBaseString(): void;
   getMyBaseString(): string | undefined;
-  setMyBaseString(value: string): void;
+  setMyBaseString(value: string): MyBase;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MyBase.AsObject;

--- a/examples/generated/proto/examplecom/getter_name_pb.d.ts
+++ b/examples/generated/proto/examplecom/getter_name_pb.d.ts
@@ -7,14 +7,14 @@ export class GetterNameConflictMessage extends jspb.Message {
   hasExtension$(): boolean;
   clearExtension$(): void;
   getExtension$(): string | undefined;
-  setExtension$(value: string): void;
+  setExtension$(value: string): GetterNameConflictMessage;
 
   hasJsPbMessageId$(): boolean;
   clearJsPbMessageId$(): void;
   getJsPbMessageId$(): Uint8Array | string;
   getJsPbMessageId_asU8(): Uint8Array;
   getJsPbMessageId_asB64(): string;
-  setJsPbMessageId$(value: Uint8Array | string): void;
+  setJsPbMessageId$(value: Uint8Array | string): GetterNameConflictMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): GetterNameConflictMessage.AsObject;

--- a/examples/generated/proto/examplecom/map_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/map_message_pb.d.ts
@@ -37,7 +37,7 @@ export namespace MapMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated/proto/examplecom/oneof_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/oneof_message_pb.d.ts
@@ -8,22 +8,22 @@ export class OneOfMessage extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): OneOfMessage.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): void;
+  setInternalChildMessage(value?: OneOfMessage.InternalChildMessage): OneOfMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): OneOfMessage;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OneOfMessage;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): OneOfMessage;
 
   getGroupCase(): OneOfMessage.GroupCase;
   serializeBinary(): Uint8Array;
@@ -46,7 +46,7 @@ export namespace OneOfMessage {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;
@@ -77,12 +77,12 @@ export class CamelCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): CamelCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): CamelCasedOneOfMessage;
 
   getCamelcasedmessageCase(): CamelCasedOneOfMessage.CamelcasedmessageCase;
   serializeBinary(): Uint8Array;
@@ -112,12 +112,12 @@ export class SnakeCasedOneOfMessage extends jspb.Message {
   hasAnint(): boolean;
   clearAnint(): void;
   getAnint(): number;
-  setAnint(value: number): void;
+  setAnint(value: number): SnakeCasedOneOfMessage;
 
   hasThestring(): boolean;
   clearThestring(): void;
   getThestring(): string;
-  setThestring(value: string): void;
+  setThestring(value: string): SnakeCasedOneOfMessage;
 
   getSnakeCasedMessageCase(): SnakeCasedOneOfMessage.SnakeCasedMessageCase;
   serializeBinary(): Uint8Array;

--- a/examples/generated/proto/examplecom/parent_message_v2_pb.d.ts
+++ b/examples/generated/proto/examplecom/parent_message_v2_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV2 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV2.InternalChildMessage;
-  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV2.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV2.InternalChildMessage): ParentMessageV2;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV2.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV2.InternalChildMessage>): ParentMessageV2;
   addInternalChildren(value?: ParentMessageV2.InternalChildMessage, index?: number): ParentMessageV2.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV2;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV2;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -59,7 +59,7 @@ export namespace ParentMessageV2 {
     hasMyString(): boolean;
     clearMyString(): void;
     getMyString(): string | undefined;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/parent_message_v3_pb.d.ts
@@ -8,31 +8,31 @@ export class ParentMessageV3 extends jspb.Message {
   hasInternalChildMessage(): boolean;
   clearInternalChildMessage(): void;
   getInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   hasOptInternalChildMessage(): boolean;
   clearOptInternalChildMessage(): void;
   getOptInternalChildMessage(): ParentMessageV3.InternalChildMessage | undefined;
-  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): void;
+  setOptInternalChildMessage(value?: ParentMessageV3.InternalChildMessage): ParentMessageV3;
 
   clearInternalChildrenList(): void;
   getInternalChildrenList(): Array<ParentMessageV3.InternalChildMessage>;
-  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): void;
+  setInternalChildrenList(value: Array<ParentMessageV3.InternalChildMessage>): ParentMessageV3;
   addInternalChildren(value?: ParentMessageV3.InternalChildMessage, index?: number): ParentMessageV3.InternalChildMessage;
 
   hasExternalChildMessage(): boolean;
   clearExternalChildMessage(): void;
   getExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   hasOptExternalChildMessage(): boolean;
   clearOptExternalChildMessage(): void;
   getOptExternalChildMessage(): proto_othercom_external_child_message_pb.ExternalChildMessage | undefined;
-  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): void;
+  setOptExternalChildMessage(value?: proto_othercom_external_child_message_pb.ExternalChildMessage): ParentMessageV3;
 
   clearExternalChildrenList(): void;
   getExternalChildrenList(): Array<proto_othercom_external_child_message_pb.ExternalChildMessage>;
-  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): void;
+  setExternalChildrenList(value: Array<proto_othercom_external_child_message_pb.ExternalChildMessage>): ParentMessageV3;
   addExternalChildren(value?: proto_othercom_external_child_message_pb.ExternalChildMessage, index?: number): proto_othercom_external_child_message_pb.ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
@@ -57,7 +57,7 @@ export namespace ParentMessageV3 {
 
   export class InternalChildMessage extends jspb.Message {
     getMyString(): string;
-    setMyString(value: string): void;
+    setMyString(value: string): InternalChildMessage;
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): InternalChildMessage.AsObject;

--- a/examples/generated/proto/examplecom/primitive_message_v2_pb.d.ts
+++ b/examples/generated/proto/examplecom/primitive_message_v2_pb.d.ts
@@ -7,161 +7,161 @@ export class PrimitiveMessageV2 extends jspb.Message {
   hasMyDouble(): boolean;
   clearMyDouble(): void;
   getMyDouble(): number | undefined;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV2;
 
   hasMyFloat(): boolean;
   clearMyFloat(): void;
   getMyFloat(): number | undefined;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV2;
 
   hasMyInt32(): boolean;
   clearMyInt32(): void;
   getMyInt32(): number | undefined;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV2;
 
   hasMyInt64(): boolean;
   clearMyInt64(): void;
   getMyInt64(): number | undefined;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV2;
 
   hasMyUint32(): boolean;
   clearMyUint32(): void;
   getMyUint32(): number | undefined;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV2;
 
   hasMyUint64(): boolean;
   clearMyUint64(): void;
   getMyUint64(): number | undefined;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV2;
 
   hasMySint32(): boolean;
   clearMySint32(): void;
   getMySint32(): number | undefined;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV2;
 
   hasMySint64(): boolean;
   clearMySint64(): void;
   getMySint64(): number | undefined;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV2;
 
   hasMyFixed32(): boolean;
   clearMyFixed32(): void;
   getMyFixed32(): number | undefined;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV2;
 
   hasMyFixed64(): boolean;
   clearMyFixed64(): void;
   getMyFixed64(): number | undefined;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV2;
 
   hasMySfixed32(): boolean;
   clearMySfixed32(): void;
   getMySfixed32(): number | undefined;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV2;
 
   hasMySfixed64(): boolean;
   clearMySfixed64(): void;
   getMySfixed64(): number | undefined;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV2;
 
   hasMyBool(): boolean;
   clearMyBool(): void;
   getMyBool(): boolean | undefined;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV2;
 
   hasMyString(): boolean;
   clearMyString(): void;
   getMyString(): string | undefined;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV2;
 
   hasMyBytes(): boolean;
   clearMyBytes(): void;
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number | undefined;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV2;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number | undefined;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV2;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number | undefined;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV2;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number | undefined;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV2;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number | undefined;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV2;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number | undefined;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV2;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number | undefined;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV2;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number | undefined;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV2;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number | undefined;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV2;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number | undefined;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV2;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number | undefined;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV2;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number | undefined;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV2;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean | undefined;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV2;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string | undefined;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV2;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV2;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number | undefined;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV2;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV2.AsObject;

--- a/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
+++ b/examples/generated/proto/examplecom/primitive_message_v3_pb.d.ts
@@ -5,136 +5,136 @@ import * as jspb from "google-protobuf";
 
 export class PrimitiveMessageV3 extends jspb.Message {
   getMyDouble(): number;
-  setMyDouble(value: number): void;
+  setMyDouble(value: number): PrimitiveMessageV3;
 
   getMyFloat(): number;
-  setMyFloat(value: number): void;
+  setMyFloat(value: number): PrimitiveMessageV3;
 
   getMyInt32(): number;
-  setMyInt32(value: number): void;
+  setMyInt32(value: number): PrimitiveMessageV3;
 
   getMyInt64(): number;
-  setMyInt64(value: number): void;
+  setMyInt64(value: number): PrimitiveMessageV3;
 
   getMyUint32(): number;
-  setMyUint32(value: number): void;
+  setMyUint32(value: number): PrimitiveMessageV3;
 
   getMyUint64(): number;
-  setMyUint64(value: number): void;
+  setMyUint64(value: number): PrimitiveMessageV3;
 
   getMySint32(): number;
-  setMySint32(value: number): void;
+  setMySint32(value: number): PrimitiveMessageV3;
 
   getMySint64(): number;
-  setMySint64(value: number): void;
+  setMySint64(value: number): PrimitiveMessageV3;
 
   getMyFixed32(): number;
-  setMyFixed32(value: number): void;
+  setMyFixed32(value: number): PrimitiveMessageV3;
 
   getMyFixed64(): number;
-  setMyFixed64(value: number): void;
+  setMyFixed64(value: number): PrimitiveMessageV3;
 
   getMySfixed32(): number;
-  setMySfixed32(value: number): void;
+  setMySfixed32(value: number): PrimitiveMessageV3;
 
   getMySfixed64(): number;
-  setMySfixed64(value: number): void;
+  setMySfixed64(value: number): PrimitiveMessageV3;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): PrimitiveMessageV3;
 
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): PrimitiveMessageV3;
 
   getMyBytes(): Uint8Array | string;
   getMyBytes_asU8(): Uint8Array;
   getMyBytes_asB64(): string;
-  setMyBytes(value: Uint8Array | string): void;
+  setMyBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   getMyNumber(): number;
-  setMyNumber(value: number): void;
+  setMyNumber(value: number): PrimitiveMessageV3;
 
   hasOptDouble(): boolean;
   clearOptDouble(): void;
   getOptDouble(): number;
-  setOptDouble(value: number): void;
+  setOptDouble(value: number): PrimitiveMessageV3;
 
   hasOptFloat(): boolean;
   clearOptFloat(): void;
   getOptFloat(): number;
-  setOptFloat(value: number): void;
+  setOptFloat(value: number): PrimitiveMessageV3;
 
   hasOptInt32(): boolean;
   clearOptInt32(): void;
   getOptInt32(): number;
-  setOptInt32(value: number): void;
+  setOptInt32(value: number): PrimitiveMessageV3;
 
   hasOptInt64(): boolean;
   clearOptInt64(): void;
   getOptInt64(): number;
-  setOptInt64(value: number): void;
+  setOptInt64(value: number): PrimitiveMessageV3;
 
   hasOptUint32(): boolean;
   clearOptUint32(): void;
   getOptUint32(): number;
-  setOptUint32(value: number): void;
+  setOptUint32(value: number): PrimitiveMessageV3;
 
   hasOptUint64(): boolean;
   clearOptUint64(): void;
   getOptUint64(): number;
-  setOptUint64(value: number): void;
+  setOptUint64(value: number): PrimitiveMessageV3;
 
   hasOptSint32(): boolean;
   clearOptSint32(): void;
   getOptSint32(): number;
-  setOptSint32(value: number): void;
+  setOptSint32(value: number): PrimitiveMessageV3;
 
   hasOptSint64(): boolean;
   clearOptSint64(): void;
   getOptSint64(): number;
-  setOptSint64(value: number): void;
+  setOptSint64(value: number): PrimitiveMessageV3;
 
   hasOptFixed32(): boolean;
   clearOptFixed32(): void;
   getOptFixed32(): number;
-  setOptFixed32(value: number): void;
+  setOptFixed32(value: number): PrimitiveMessageV3;
 
   hasOptFixed64(): boolean;
   clearOptFixed64(): void;
   getOptFixed64(): number;
-  setOptFixed64(value: number): void;
+  setOptFixed64(value: number): PrimitiveMessageV3;
 
   hasOptSfixed32(): boolean;
   clearOptSfixed32(): void;
   getOptSfixed32(): number;
-  setOptSfixed32(value: number): void;
+  setOptSfixed32(value: number): PrimitiveMessageV3;
 
   hasOptSfixed64(): boolean;
   clearOptSfixed64(): void;
   getOptSfixed64(): number;
-  setOptSfixed64(value: number): void;
+  setOptSfixed64(value: number): PrimitiveMessageV3;
 
   hasOptBool(): boolean;
   clearOptBool(): void;
   getOptBool(): boolean;
-  setOptBool(value: boolean): void;
+  setOptBool(value: boolean): PrimitiveMessageV3;
 
   hasOptString(): boolean;
   clearOptString(): void;
   getOptString(): string;
-  setOptString(value: string): void;
+  setOptString(value: string): PrimitiveMessageV3;
 
   hasOptBytes(): boolean;
   clearOptBytes(): void;
   getOptBytes(): Uint8Array | string;
   getOptBytes_asU8(): Uint8Array;
   getOptBytes_asB64(): string;
-  setOptBytes(value: Uint8Array | string): void;
+  setOptBytes(value: Uint8Array | string): PrimitiveMessageV3;
 
   hasOptNumber(): boolean;
   clearOptNumber(): void;
   getOptNumber(): number;
-  setOptNumber(value: number): void;
+  setOptNumber(value: number): PrimitiveMessageV3;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): PrimitiveMessageV3.AsObject;

--- a/examples/generated/proto/examplecom/repeated_primitive_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/repeated_primitive_message_pb.d.ts
@@ -6,79 +6,79 @@ import * as jspb from "google-protobuf";
 export class RepeatedPrimitiveMessage extends jspb.Message {
   clearMyDoubleList(): void;
   getMyDoubleList(): Array<number>;
-  setMyDoubleList(value: Array<number>): void;
+  setMyDoubleList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyDouble(value: number, index?: number): number;
 
   clearMyFloatList(): void;
   getMyFloatList(): Array<number>;
-  setMyFloatList(value: Array<number>): void;
+  setMyFloatList(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFloat(value: number, index?: number): number;
 
   clearMyInt32List(): void;
   getMyInt32List(): Array<number>;
-  setMyInt32List(value: Array<number>): void;
+  setMyInt32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt32(value: number, index?: number): number;
 
   clearMyInt64List(): void;
   getMyInt64List(): Array<number>;
-  setMyInt64List(value: Array<number>): void;
+  setMyInt64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyInt64(value: number, index?: number): number;
 
   clearMyUint32List(): void;
   getMyUint32List(): Array<number>;
-  setMyUint32List(value: Array<number>): void;
+  setMyUint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint32(value: number, index?: number): number;
 
   clearMyUint64List(): void;
   getMyUint64List(): Array<number>;
-  setMyUint64List(value: Array<number>): void;
+  setMyUint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyUint64(value: number, index?: number): number;
 
   clearMySint32List(): void;
   getMySint32List(): Array<number>;
-  setMySint32List(value: Array<number>): void;
+  setMySint32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint32(value: number, index?: number): number;
 
   clearMySint64List(): void;
   getMySint64List(): Array<number>;
-  setMySint64List(value: Array<number>): void;
+  setMySint64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySint64(value: number, index?: number): number;
 
   clearMyFixed32List(): void;
   getMyFixed32List(): Array<number>;
-  setMyFixed32List(value: Array<number>): void;
+  setMyFixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed32(value: number, index?: number): number;
 
   clearMyFixed64List(): void;
   getMyFixed64List(): Array<number>;
-  setMyFixed64List(value: Array<number>): void;
+  setMyFixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMyFixed64(value: number, index?: number): number;
 
   clearMySfixed32List(): void;
   getMySfixed32List(): Array<number>;
-  setMySfixed32List(value: Array<number>): void;
+  setMySfixed32List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed32(value: number, index?: number): number;
 
   clearMySfixed64List(): void;
   getMySfixed64List(): Array<number>;
-  setMySfixed64List(value: Array<number>): void;
+  setMySfixed64List(value: Array<number>): RepeatedPrimitiveMessage;
   addMySfixed64(value: number, index?: number): number;
 
   clearMyBoolList(): void;
   getMyBoolList(): Array<boolean>;
-  setMyBoolList(value: Array<boolean>): void;
+  setMyBoolList(value: Array<boolean>): RepeatedPrimitiveMessage;
   addMyBool(value: boolean, index?: number): boolean;
 
   clearMyStringList(): void;
   getMyStringList(): Array<string>;
-  setMyStringList(value: Array<string>): void;
+  setMyStringList(value: Array<string>): RepeatedPrimitiveMessage;
   addMyString(value: string, index?: number): string;
 
   clearMyBytesList(): void;
   getMyBytesList(): Array<Uint8Array | string>;
   getMyBytesList_asU8(): Array<Uint8Array>;
   getMyBytesList_asB64(): Array<string>;
-  setMyBytesList(value: Array<Uint8Array | string>): void;
+  setMyBytesList(value: Array<Uint8Array | string>): RepeatedPrimitiveMessage;
   addMyBytes(value: Uint8Array | string, index?: number): Uint8Array | string;
 
   serializeBinary(): Uint8Array;

--- a/examples/generated/proto/examplecom/reserved_words_pb.d.ts
+++ b/examples/generated/proto/examplecom/reserved_words_pb.d.ts
@@ -5,178 +5,178 @@ import * as jspb from "google-protobuf";
 
 export class ReservedWordsMessage extends jspb.Message {
   getAbstract(): string;
-  setAbstract(value: string): void;
+  setAbstract(value: string): ReservedWordsMessage;
 
   getBoolean(): string;
-  setBoolean(value: string): void;
+  setBoolean(value: string): ReservedWordsMessage;
 
   getBreak(): string;
-  setBreak(value: string): void;
+  setBreak(value: string): ReservedWordsMessage;
 
   getByte(): string;
-  setByte(value: string): void;
+  setByte(value: string): ReservedWordsMessage;
 
   getCase(): string;
-  setCase(value: string): void;
+  setCase(value: string): ReservedWordsMessage;
 
   getCatch(): string;
-  setCatch(value: string): void;
+  setCatch(value: string): ReservedWordsMessage;
 
   getChar(): string;
-  setChar(value: string): void;
+  setChar(value: string): ReservedWordsMessage;
 
   getClass(): string;
-  setClass(value: string): void;
+  setClass(value: string): ReservedWordsMessage;
 
   getConst(): string;
-  setConst(value: string): void;
+  setConst(value: string): ReservedWordsMessage;
 
   getContinue(): string;
-  setContinue(value: string): void;
+  setContinue(value: string): ReservedWordsMessage;
 
   getDebugger(): string;
-  setDebugger(value: string): void;
+  setDebugger(value: string): ReservedWordsMessage;
 
   getDefault(): string;
-  setDefault(value: string): void;
+  setDefault(value: string): ReservedWordsMessage;
 
   getDelete(): string;
-  setDelete(value: string): void;
+  setDelete(value: string): ReservedWordsMessage;
 
   getDo(): string;
-  setDo(value: string): void;
+  setDo(value: string): ReservedWordsMessage;
 
   getDouble(): string;
-  setDouble(value: string): void;
+  setDouble(value: string): ReservedWordsMessage;
 
   getElse(): string;
-  setElse(value: string): void;
+  setElse(value: string): ReservedWordsMessage;
 
   getEnum(): string;
-  setEnum(value: string): void;
+  setEnum(value: string): ReservedWordsMessage;
 
   getExport(): string;
-  setExport(value: string): void;
+  setExport(value: string): ReservedWordsMessage;
 
   getExtends(): string;
-  setExtends(value: string): void;
+  setExtends(value: string): ReservedWordsMessage;
 
   getFalse(): string;
-  setFalse(value: string): void;
+  setFalse(value: string): ReservedWordsMessage;
 
   getFinal(): string;
-  setFinal(value: string): void;
+  setFinal(value: string): ReservedWordsMessage;
 
   getFinally(): string;
-  setFinally(value: string): void;
+  setFinally(value: string): ReservedWordsMessage;
 
   getFloat(): string;
-  setFloat(value: string): void;
+  setFloat(value: string): ReservedWordsMessage;
 
   getFor(): string;
-  setFor(value: string): void;
+  setFor(value: string): ReservedWordsMessage;
 
   getFunction(): string;
-  setFunction(value: string): void;
+  setFunction(value: string): ReservedWordsMessage;
 
   getGoto(): string;
-  setGoto(value: string): void;
+  setGoto(value: string): ReservedWordsMessage;
 
   getIf(): string;
-  setIf(value: string): void;
+  setIf(value: string): ReservedWordsMessage;
 
   getImplements(): string;
-  setImplements(value: string): void;
+  setImplements(value: string): ReservedWordsMessage;
 
   getImport(): string;
-  setImport(value: string): void;
+  setImport(value: string): ReservedWordsMessage;
 
   getIn(): string;
-  setIn(value: string): void;
+  setIn(value: string): ReservedWordsMessage;
 
   getInstanceof(): string;
-  setInstanceof(value: string): void;
+  setInstanceof(value: string): ReservedWordsMessage;
 
   getInt(): string;
-  setInt(value: string): void;
+  setInt(value: string): ReservedWordsMessage;
 
   getInterface(): string;
-  setInterface(value: string): void;
+  setInterface(value: string): ReservedWordsMessage;
 
   getLong(): string;
-  setLong(value: string): void;
+  setLong(value: string): ReservedWordsMessage;
 
   getNative(): string;
-  setNative(value: string): void;
+  setNative(value: string): ReservedWordsMessage;
 
   getNew(): string;
-  setNew(value: string): void;
+  setNew(value: string): ReservedWordsMessage;
 
   getNull(): string;
-  setNull(value: string): void;
+  setNull(value: string): ReservedWordsMessage;
 
   getPackage(): string;
-  setPackage(value: string): void;
+  setPackage(value: string): ReservedWordsMessage;
 
   getPrivate(): string;
-  setPrivate(value: string): void;
+  setPrivate(value: string): ReservedWordsMessage;
 
   getProtected(): string;
-  setProtected(value: string): void;
+  setProtected(value: string): ReservedWordsMessage;
 
   getPublic(): string;
-  setPublic(value: string): void;
+  setPublic(value: string): ReservedWordsMessage;
 
   getReturn(): string;
-  setReturn(value: string): void;
+  setReturn(value: string): ReservedWordsMessage;
 
   getShort(): string;
-  setShort(value: string): void;
+  setShort(value: string): ReservedWordsMessage;
 
   getStatic(): string;
-  setStatic(value: string): void;
+  setStatic(value: string): ReservedWordsMessage;
 
   getSuper(): string;
-  setSuper(value: string): void;
+  setSuper(value: string): ReservedWordsMessage;
 
   getSwitch(): string;
-  setSwitch(value: string): void;
+  setSwitch(value: string): ReservedWordsMessage;
 
   getSynchronized(): string;
-  setSynchronized(value: string): void;
+  setSynchronized(value: string): ReservedWordsMessage;
 
   getThis(): string;
-  setThis(value: string): void;
+  setThis(value: string): ReservedWordsMessage;
 
   getThrow(): string;
-  setThrow(value: string): void;
+  setThrow(value: string): ReservedWordsMessage;
 
   getThrows(): string;
-  setThrows(value: string): void;
+  setThrows(value: string): ReservedWordsMessage;
 
   getTransient(): string;
-  setTransient(value: string): void;
+  setTransient(value: string): ReservedWordsMessage;
 
   getTry(): string;
-  setTry(value: string): void;
+  setTry(value: string): ReservedWordsMessage;
 
   getTypeof(): string;
-  setTypeof(value: string): void;
+  setTypeof(value: string): ReservedWordsMessage;
 
   getVar(): string;
-  setVar(value: string): void;
+  setVar(value: string): ReservedWordsMessage;
 
   getVoid(): string;
-  setVoid(value: string): void;
+  setVoid(value: string): ReservedWordsMessage;
 
   getVolatile(): string;
-  setVolatile(value: string): void;
+  setVolatile(value: string): ReservedWordsMessage;
 
   getWhile(): string;
-  setWhile(value: string): void;
+  setWhile(value: string): ReservedWordsMessage;
 
   getWith(): string;
-  setWith(value: string): void;
+  setWith(value: string): ReservedWordsMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ReservedWordsMessage.AsObject;

--- a/examples/generated/proto/examplecom/simple_pb.d.ts
+++ b/examples/generated/proto/examplecom/simple_pb.d.ts
@@ -17,75 +17,75 @@ import * as google_protobuf_wrappers_pb from "google-protobuf/google/protobuf/wr
 
 export class MySimple extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): MySimple;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): MySimple;
 
   clearSomeLabelsList(): void;
   getSomeLabelsList(): Array<string>;
-  setSomeLabelsList(value: Array<string>): void;
+  setSomeLabelsList(value: Array<string>): MySimple;
   addSomeLabels(value: string, index?: number): string;
 
   hasSomeCodeGeneratorRequest(): boolean;
   clearSomeCodeGeneratorRequest(): void;
   getSomeCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setSomeCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): MySimple;
 
   hasSomeAny(): boolean;
   clearSomeAny(): void;
   getSomeAny(): google_protobuf_any_pb.Any | undefined;
-  setSomeAny(value?: google_protobuf_any_pb.Any): void;
+  setSomeAny(value?: google_protobuf_any_pb.Any): MySimple;
 
   hasSomeMethod(): boolean;
   clearSomeMethod(): void;
   getSomeMethod(): google_protobuf_api_pb.Method | undefined;
-  setSomeMethod(value?: google_protobuf_api_pb.Method): void;
+  setSomeMethod(value?: google_protobuf_api_pb.Method): MySimple;
 
   hasSomeGeneratedCodeInfo(): boolean;
   clearSomeGeneratedCodeInfo(): void;
   getSomeGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setSomeGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): MySimple;
 
   hasSomeDuration(): boolean;
   clearSomeDuration(): void;
   getSomeDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setSomeDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setSomeDuration(value?: google_protobuf_duration_pb.Duration): MySimple;
 
   hasSomeEmpty(): boolean;
   clearSomeEmpty(): void;
   getSomeEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setSomeEmpty(value?: google_protobuf_empty_pb.Empty): MySimple;
 
   hasSomeFieldMask(): boolean;
   clearSomeFieldMask(): void;
   getSomeFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setSomeFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): MySimple;
 
   hasSomeSourceContext(): boolean;
   clearSomeSourceContext(): void;
   getSomeSourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setSomeSourceContext(value?: google_protobuf_source_context_pb.SourceContext): MySimple;
 
   hasSomeStruct(): boolean;
   clearSomeStruct(): void;
   getSomeStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setSomeStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setSomeStruct(value?: google_protobuf_struct_pb.Struct): MySimple;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): MySimple;
 
   hasSomeType(): boolean;
   clearSomeType(): void;
   getSomeType(): google_protobuf_type_pb.Type | undefined;
-  setSomeType(value?: google_protobuf_type_pb.Type): void;
+  setSomeType(value?: google_protobuf_type_pb.Type): MySimple;
 
   hasSomeDoubleValue(): boolean;
   clearSomeDoubleValue(): void;
   getSomeDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setSomeDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): MySimple;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): MySimple.AsObject;

--- a/examples/generated/proto/examplecom/simple_service_pb.d.ts
+++ b/examples/generated/proto/examplecom/simple_service_pb.d.ts
@@ -8,12 +8,12 @@ import * as google_protobuf_timestamp_pb from "google-protobuf/google/protobuf/t
 
 export class UnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): UnaryRequest;
 
   hasSomeTimestamp(): boolean;
   clearSomeTimestamp(): void;
   getSomeTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setSomeTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): UnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): UnaryRequest.AsObject;
@@ -50,7 +50,7 @@ export namespace UnaryResponse {
 
 export class StreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): StreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): StreamRequest.AsObject;

--- a/examples/generated/proto/examplecom/simplevalue_pb.d.ts
+++ b/examples/generated/proto/examplecom/simplevalue_pb.d.ts
@@ -5,40 +5,40 @@ import * as jspb from "google-protobuf";
 
 export class SimpleValue extends jspb.Message {
   getFirstField(): string;
-  setFirstField(value: string): void;
+  setFirstField(value: string): SimpleValue;
 
   getSecondField(): number;
-  setSecondField(value: number): void;
+  setSecondField(value: number): SimpleValue;
 
   hasNumberValue(): boolean;
   clearNumberValue(): void;
   getNumberValue(): number;
-  setNumberValue(value: number): void;
+  setNumberValue(value: number): SimpleValue;
 
   hasStringValue(): boolean;
   clearStringValue(): void;
   getStringValue(): string;
-  setStringValue(value: string): void;
+  setStringValue(value: string): SimpleValue;
 
   hasBoolValue(): boolean;
   clearBoolValue(): void;
   getBoolValue(): boolean;
-  setBoolValue(value: boolean): void;
+  setBoolValue(value: boolean): SimpleValue;
 
   hasNumber2Value(): boolean;
   clearNumber2Value(): void;
   getNumber2Value(): number;
-  setNumber2Value(value: number): void;
+  setNumber2Value(value: number): SimpleValue;
 
   hasString2Value(): boolean;
   clearString2Value(): void;
   getString2Value(): string;
-  setString2Value(value: string): void;
+  setString2Value(value: string): SimpleValue;
 
   hasBool2Value(): boolean;
   clearBool2Value(): void;
   getBool2Value(): boolean;
-  setBool2Value(value: boolean): void;
+  setBool2Value(value: boolean): SimpleValue;
 
   getKindCase(): SimpleValue.KindCase;
   getAnotherCase(): SimpleValue.AnotherCase;

--- a/examples/generated/proto/examplecom/well_known_message_pb.d.ts
+++ b/examples/generated/proto/examplecom/well_known_message_pb.d.ts
@@ -19,62 +19,62 @@ export class WellKnownMessage extends jspb.Message {
   hasMyCodeGeneratorRequest(): boolean;
   clearMyCodeGeneratorRequest(): void;
   getMyCodeGeneratorRequest(): google_protobuf_compiler_plugin_pb.CodeGeneratorRequest | undefined;
-  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): void;
+  setMyCodeGeneratorRequest(value?: google_protobuf_compiler_plugin_pb.CodeGeneratorRequest): WellKnownMessage;
 
   hasMyAny(): boolean;
   clearMyAny(): void;
   getMyAny(): google_protobuf_any_pb.Any | undefined;
-  setMyAny(value?: google_protobuf_any_pb.Any): void;
+  setMyAny(value?: google_protobuf_any_pb.Any): WellKnownMessage;
 
   hasMyMethod(): boolean;
   clearMyMethod(): void;
   getMyMethod(): google_protobuf_api_pb.Method | undefined;
-  setMyMethod(value?: google_protobuf_api_pb.Method): void;
+  setMyMethod(value?: google_protobuf_api_pb.Method): WellKnownMessage;
 
   hasMyGeneratedCodeInfo(): boolean;
   clearMyGeneratedCodeInfo(): void;
   getMyGeneratedCodeInfo(): google_protobuf_descriptor_pb.GeneratedCodeInfo | undefined;
-  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): void;
+  setMyGeneratedCodeInfo(value?: google_protobuf_descriptor_pb.GeneratedCodeInfo): WellKnownMessage;
 
   hasMyDuration(): boolean;
   clearMyDuration(): void;
   getMyDuration(): google_protobuf_duration_pb.Duration | undefined;
-  setMyDuration(value?: google_protobuf_duration_pb.Duration): void;
+  setMyDuration(value?: google_protobuf_duration_pb.Duration): WellKnownMessage;
 
   hasMyEmpty(): boolean;
   clearMyEmpty(): void;
   getMyEmpty(): google_protobuf_empty_pb.Empty | undefined;
-  setMyEmpty(value?: google_protobuf_empty_pb.Empty): void;
+  setMyEmpty(value?: google_protobuf_empty_pb.Empty): WellKnownMessage;
 
   hasMyFieldMask(): boolean;
   clearMyFieldMask(): void;
   getMyFieldMask(): google_protobuf_field_mask_pb.FieldMask | undefined;
-  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): void;
+  setMyFieldMask(value?: google_protobuf_field_mask_pb.FieldMask): WellKnownMessage;
 
   hasMySourceContext(): boolean;
   clearMySourceContext(): void;
   getMySourceContext(): google_protobuf_source_context_pb.SourceContext | undefined;
-  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): void;
+  setMySourceContext(value?: google_protobuf_source_context_pb.SourceContext): WellKnownMessage;
 
   hasMyStruct(): boolean;
   clearMyStruct(): void;
   getMyStruct(): google_protobuf_struct_pb.Struct | undefined;
-  setMyStruct(value?: google_protobuf_struct_pb.Struct): void;
+  setMyStruct(value?: google_protobuf_struct_pb.Struct): WellKnownMessage;
 
   hasMyTimestamp(): boolean;
   clearMyTimestamp(): void;
   getMyTimestamp(): google_protobuf_timestamp_pb.Timestamp | undefined;
-  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): void;
+  setMyTimestamp(value?: google_protobuf_timestamp_pb.Timestamp): WellKnownMessage;
 
   hasMyType(): boolean;
   clearMyType(): void;
   getMyType(): google_protobuf_type_pb.Type | undefined;
-  setMyType(value?: google_protobuf_type_pb.Type): void;
+  setMyType(value?: google_protobuf_type_pb.Type): WellKnownMessage;
 
   hasMyDoubleValue(): boolean;
   clearMyDoubleValue(): void;
   getMyDoubleValue(): google_protobuf_wrappers_pb.DoubleValue | undefined;
-  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): void;
+  setMyDoubleValue(value?: google_protobuf_wrappers_pb.DoubleValue): WellKnownMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): WellKnownMessage.AsObject;

--- a/examples/generated/proto/orphan_pb.d.ts
+++ b/examples/generated/proto/orphan_pb.d.ts
@@ -24,13 +24,13 @@ export namespace OrphanMapMessage {
 
 export class OrphanMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): OrphanMessage;
 
   getMyBool(): boolean;
-  setMyBool(value: boolean): void;
+  setMyBool(value: boolean): OrphanMessage;
 
   getMyEnum(): OrphanEnumMap[keyof OrphanEnumMap];
-  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): void;
+  setMyEnum(value: OrphanEnumMap[keyof OrphanEnumMap]): OrphanMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanMessage.AsObject;
@@ -52,7 +52,7 @@ export namespace OrphanMessage {
 
 export class OrphanUnaryRequest extends jspb.Message {
   getSomeInt64(): number;
-  setSomeInt64(value: number): void;
+  setSomeInt64(value: number): OrphanUnaryRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanUnaryRequest.AsObject;
@@ -72,7 +72,7 @@ export namespace OrphanUnaryRequest {
 
 export class OrphanStreamRequest extends jspb.Message {
   getSomeString(): string;
-  setSomeString(value: string): void;
+  setSomeString(value: string): OrphanStreamRequest;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): OrphanStreamRequest.AsObject;

--- a/examples/generated/proto/othercom/external_child_message_pb.d.ts
+++ b/examples/generated/proto/othercom/external_child_message_pb.d.ts
@@ -5,7 +5,7 @@ import * as jspb from "google-protobuf";
 
 export class ExternalChildMessage extends jspb.Message {
   getMyString(): string;
-  setMyString(value: string): void;
+  setMyString(value: string): ExternalChildMessage;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ExternalChildMessage.AsObject;

--- a/src/ts/message.ts
+++ b/src/ts/message.ts
@@ -184,12 +184,12 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
         printer.printIndentedLn(`get${withUppercase}List(): Array<Uint8Array | string>;`);
         printer.printIndentedLn(`get${withUppercase}List_asU8(): Array<Uint8Array>;`);
         printer.printIndentedLn(`get${withUppercase}List_asB64(): Array<string>;`);
-        printer.printIndentedLn(`set${withUppercase}List(value: Array<Uint8Array | string>): void;`);
+        printer.printIndentedLn(`set${withUppercase}List(value: Array<Uint8Array | string>): ${messageName};`);
         printRepeatedAddMethod("Uint8Array | string");
       } else {
         toObjectType.printIndentedLn(`${camelCaseName}List: Array<${exportType}${type === MESSAGE_TYPE ? ".AsObject" : ""}>,`);
         printer.printIndentedLn(`get${withUppercase}List(): Array<${exportType}>;`);
-        printer.printIndentedLn(`set${withUppercase}List(value: Array<${exportType}>): void;`);
+        printer.printIndentedLn(`set${withUppercase}List(value: Array<${exportType}>): ${messageName};`);
         printRepeatedAddMethod(exportType);
       }
     } else {
@@ -198,7 +198,7 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
         printer.printIndentedLn(`get${jsGetterName(withUppercase)}(): Uint8Array | string;`);
         printer.printIndentedLn(`get${withUppercase}_asU8(): Uint8Array;`);
         printer.printIndentedLn(`get${withUppercase}_asB64(): string;`);
-        printer.printIndentedLn(`set${jsGetterName(withUppercase)}(value: Uint8Array | string): void;`);
+        printer.printIndentedLn(`set${jsGetterName(withUppercase)}(value: Uint8Array | string): ${messageName};`);
       } else {
         let fieldObjectType = exportType;
         let canBeUndefined = false;
@@ -215,7 +215,7 @@ export function printMessage(fileName: string, exportMap: ExportMap, messageDesc
         const fieldObjectName = normaliseFieldObjectName(camelCaseName);
         toObjectType.printIndentedLn(`${fieldObjectName}${canBeUndefined ? "?" : ""}: ${fieldObjectType},`);
         printer.printIndentedLn(`get${jsGetterName(withUppercase)}(): ${exportType}${canBeUndefined ? " | undefined" : ""};`);
-        printer.printIndentedLn(`set${jsGetterName(withUppercase)}(value${type === MESSAGE_TYPE ? "?" : ""}: ${exportType}): void;`);
+        printer.printIndentedLn(`set${jsGetterName(withUppercase)}(value${type === MESSAGE_TYPE ? "?" : ""}: ${exportType}): ${messageName};`);
       }
     }
     printer.printEmptyLn();

--- a/test/integration/enums.ts
+++ b/test/integration/enums.ts
@@ -50,3 +50,12 @@ describe("enum casing", () => {
     assert.ok(true, ".d.ts file should export the enum definition in ALL_CAPS");
   });
 });
+
+describe("enum set chaining", () => {
+  it("should support chaining set calls on enum fields", () => {
+    const parentMsg = new EnumMessage();
+    parentMsg.setInternalEnum(InternalEnum.FIRST).setInternalEnumsList([InternalEnum.SECOND]);
+    assert.strictEqual(parentMsg.getInternalEnum(), InternalEnum.FIRST);
+    assert.deepEqual(parentMsg.getInternalEnumsList(), [InternalEnum.SECOND]);
+  });
+});

--- a/test/integration/primitivesV2.ts
+++ b/test/integration/primitivesV2.ts
@@ -187,6 +187,41 @@ describe("proto2 - primitive", () => {
     assert.deepEqual(msg.getOptBytes() as (Uint8Array|string), asUint8Array);
   });
 
+  it("should allow chaining setters", () => {
+    const msg = new PrimitiveMessageV2();
+    msg
+      .setMyDouble(123)
+      .setMyFloat(123)
+      .setMyInt32(123)
+      .setMyInt64(123)
+      .setMyUint32(123)
+      .setMyUint64(123)
+      .setMySint32(123)
+      .setMySint64(123)
+      .setMyFixed32(123)
+      .setMyFixed64(123)
+      .setMySfixed32(123)
+      .setMySfixed64(123)
+      .setMyBool(true)
+      .setMyString("hello world")
+      .setMyBytes("AAECAwQFBgcICQ==");
+    assert.strictEqual(msg.getMyDouble() as number, 123);
+    assert.strictEqual(msg.getMyFloat() as number, 123);
+    assert.strictEqual(msg.getMyInt32() as number, 123);
+    assert.strictEqual(msg.getMyInt64() as number, 123);
+    assert.strictEqual(msg.getMyUint32() as number, 123);
+    assert.strictEqual(msg.getMyUint64() as number, 123);
+    assert.strictEqual(msg.getMySint32() as number, 123);
+    assert.strictEqual(msg.getMySint64() as number, 123);
+    assert.strictEqual(msg.getMyFixed32() as number, 123);
+    assert.strictEqual(msg.getMyFixed64() as number, 123);
+    assert.strictEqual(msg.getMySfixed32() as number, 123);
+    assert.strictEqual(msg.getMySfixed64() as number, 123);
+    assert.strictEqual(msg.getMyBool() as boolean, true);
+    assert.strictEqual(msg.getMyString() as string, "hello world");
+    assert.strictEqual(msg.getMyBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
+  });
+
   describe("toObject", () => {
     it("should indicate potentially undefined primitive fields", () => {
       const msg = new PrimitiveMessageV2();

--- a/test/integration/primitivesV3.ts
+++ b/test/integration/primitivesV3.ts
@@ -170,6 +170,41 @@ describe("proto3 - primitive", () => {
     assert.deepEqual(msg.getMyBytes() as (Uint8Array|string), asUint8Array);
   });
 
+  it("should allow chaining setters", () => {
+    const msg = new PrimitiveMessageV3();
+    msg
+      .setMyDouble(123)
+      .setMyFloat(123)
+      .setMyInt32(123)
+      .setMyInt64(123)
+      .setMyUint32(123)
+      .setMyUint64(123)
+      .setMySint32(123)
+      .setMySint64(123)
+      .setMyFixed32(123)
+      .setMyFixed64(123)
+      .setMySfixed32(123)
+      .setMySfixed64(123)
+      .setMyBool(true)
+      .setMyString("hello world")
+      .setMyBytes("AAECAwQFBgcICQ==");
+    assert.strictEqual(msg.getMyDouble() as number, 123);
+    assert.strictEqual(msg.getMyFloat() as number, 123);
+    assert.strictEqual(msg.getMyInt32() as number, 123);
+    assert.strictEqual(msg.getMyInt64() as number, 123);
+    assert.strictEqual(msg.getMyUint32() as number, 123);
+    assert.strictEqual(msg.getMyUint64() as number, 123);
+    assert.strictEqual(msg.getMySint32() as number, 123);
+    assert.strictEqual(msg.getMySint64() as number, 123);
+    assert.strictEqual(msg.getMyFixed32() as number, 123);
+    assert.strictEqual(msg.getMyFixed64() as number, 123);
+    assert.strictEqual(msg.getMySfixed32() as number, 123);
+    assert.strictEqual(msg.getMySfixed64() as number, 123);
+    assert.strictEqual(msg.getMyBool() as boolean, true);
+    assert.strictEqual(msg.getMyString() as string, "hello world");
+    assert.strictEqual(msg.getMyBytes() as (Uint8Array|string), "AAECAwQFBgcICQ==");
+  });
+
   describe("toObject", () => {
     it("should indicate potentially undefined primitive fields", () => {
       const msg = new PrimitiveMessageV3();

--- a/test/integration/repeatedPrimitives.ts
+++ b/test/integration/repeatedPrimitives.ts
@@ -75,4 +75,39 @@ describe("repeated primitives", () => {
     const myBytesListB: Array<Uint8Array|string> = msg.getMyBytesList();
     assert.deepEqual(myBytesListB, [asStringOne, asStringTwo]);
   });
+
+  it("should allow chaining setters", () => {
+    const msg = new RepeatedPrimitiveMessage();
+    msg
+      .setMyDoubleList([123, 456])
+      .setMyFloatList([123, 456])
+      .setMyInt32List([123, 456])
+      .setMyInt64List([123, 456])
+      .setMyUint32List([123, 456])
+      .setMyUint64List([123, 456])
+      .setMySint32List([123, 456])
+      .setMySint64List([123, 456])
+      .setMyFixed32List([123, 456])
+      .setMyFixed64List([123, 456])
+      .setMySfixed32List([123, 456])
+      .setMySfixed64List([123, 456])
+      .setMyBoolList([true, false])
+      .setMyStringList(["one", "two"])
+      .setMyBytesList(["AAECAwQFBgcICQ=="]);
+    assert.deepEqual(msg.getMyDoubleList() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyFloatList() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyInt32List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyInt64List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyUint32List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyUint64List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMySint32List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMySint64List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyFixed32List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyFixed64List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMySfixed32List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMySfixed64List() as Array<number>, [123, 456]);
+    assert.deepEqual(msg.getMyBoolList() as Array<boolean>, [true, false]);
+    assert.deepEqual(msg.getMyStringList() as Array<string>, ["one", "two"]);
+    assert.deepEqual(msg.getMyBytesList() as Array<Uint8Array|string>, ["AAECAwQFBgcICQ=="]);
+  })
 });


### PR DESCRIPTION
## Changes

- message.ts - changed return type of generated setters to ${messageName}
- ran `npm run generate` to regenerate example proto generated code
- added tests that chain setter calls and verify value on generated object

## Verification

Added unit tests for chained setter methods.
