### PR TITLE
Add plugin param to only generate gRPC types

### DIFF
--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -8,3 +8,9 @@ export enum ModeParameter {
   None,
   GrpcJs
 }
+
+
+export enum GrpcOnlyParameter {
+  None,
+  Yes
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import {parse} from "querystring";
 import {FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
 import {ExportEnumEntry, ExportMessageEntry} from "./ExportMap";
-import {ServiceParameter, ModeParameter} from "./parameters";
+import {ServiceParameter, ModeParameter, GrpcOnlyParameter} from "./parameters";
 
 export function filePathToPseudoNamespace(filePath: string): string {
   return filePath.replace(".proto", "").replace(/\//g, "_").replace(/\./g, "_").replace(/\-/g, "_") + "_pb";
@@ -182,13 +182,26 @@ export function getModeParameter(mode?: string): ModeParameter {
   }
 }
 
+export function getGrpcOnlyParameter(grpcOnly?: string): GrpcOnlyParameter {
+  switch (grpcOnly) {
+    case "true":
+      return GrpcOnlyParameter.Yes;
+    case undefined:
+        return GrpcOnlyParameter.None;
+    default:
+      throw new Error(`Unrecognised grpcOnly parameter: ${grpcOnly}`);
+  }
+}
+
 export function getParameterEnums(parameter: string): {
   service: ServiceParameter,
-  mode: ModeParameter
+  mode: ModeParameter,
+  grpcOnly: GrpcOnlyParameter
 } {
-  const {service, mode} = parse(parameter, ",");
+  const {service, mode, grpcOnly} = parse(parameter, ",");
   return {
     service: getServiceParameter(service),
-    mode: getModeParameter(mode)
+    mode: getModeParameter(mode),
+    grpcOnly: getGrpcOnlyParameter(grpcOnly)
   };
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

## Changes

<!-- Enumerate changes you made -->

This change adds the `grpcOnly` parameter to the plugin in order to handle the cases where the user wants to exclusively generate the types for the grpc service only.

Prior to this change, users could not use [`grpc-tools`](https://github.com/grpc/grpc-node/tree/master/packages/grpc-tools), [`grpc-web`](https://github.com/grpc/grpc-web), and `ts-protoc-gen` simultaneously.

After this change, it is possible to let `grpc-web` generate the `.d.ts` files (using the `commonjs+dts` or `typescript` options) for the non-gRPC  generated files, while letting `ts-protoc-gen` singularly manage the generation of the `.d.ts` files for `grpc-node`

## Verification

<!-- How you tested it? How do you know it works? -->

Tested it with the following [`buf.gen.yml`](https://docs.buf.build/tour/generate-code) configuration:

```yml
version: v1

plugins:
  - name: js
    out: ./__generated/proto/js
    opt:
      - import_style=commonjs,binary

  - name: grpc-node
    path: ./node_modules/.bin/grpc_tools_node_protoc_plugin
    out: ./__generated/proto/js

  - name: grpc-web
    path: ./node_modules/.bin/protoc-gen-grpc-web
    out: ./__generated/proto/js
    opt:
      - import_style=commonjs+dts
      - mode=grpcweb

  - name: ts-node
    path: ~/Development/ts-protoc-gen/bin/protoc-gen-ts
    out: ./__generated/proto/js
    opt:
      - service=grpc-node
      - grpcOnly=true

```
