### PR TITLE
added import_style parameter to generate import statements for browser that support es6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {CodeGeneratorRequest, CodeGeneratorResponse} from "google-protobuf/googl
 import {FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
 import {generateGrpcWebService} from "./service/grpcweb";
 import {generateGrpcNodeService} from "./service/grpcnode";
-import {ServiceParameter} from "./parameters";
+import {ServiceParameter, ImportStyleParameter} from "./parameters";
 
 /**
  * This is the ProtoC compiler plugin.
@@ -28,10 +28,11 @@ withAllStdIn((inputBuff: Buffer) => {
     const fileNameToDescriptor: {[key: string]: FileDescriptorProto} = {};
 
     const parameter = codeGenRequest.getParameter();
-    const {service, mode} = getParameterEnums(parameter || "");
+    const {service, mode, importStyle} = getParameterEnums(parameter || "");
 
     const generateGrpcWebServices = service === ServiceParameter.GrpcWeb;
     const generateGrpcNodeServices = service === ServiceParameter.GrpcNode;
+    const useImportStyleES6 = importStyle === ImportStyleParameter.ES6;
 
     codeGenRequest.getProtoFileList().forEach(protoFileDescriptor => {
       const fileDescriptorName = protoFileDescriptor.getName() || throwError("Missing file descriptor name");
@@ -47,7 +48,7 @@ withAllStdIn((inputBuff: Buffer) => {
       codeGenResponse.addFile(thisFile);
 
       if (generateGrpcWebServices) {
-        generateGrpcWebService(outputFileName, fileNameToDescriptor[fileName], exportMap)
+       generateGrpcWebService(outputFileName, fileNameToDescriptor[fileName], exportMap, useImportStyleES6)
           .forEach(file => codeGenResponse.addFile(file));
       } else if (generateGrpcNodeServices) {
         const file = generateGrpcNodeService(outputFileName, fileNameToDescriptor[fileName], exportMap, mode);

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -8,3 +8,8 @@ export enum ModeParameter {
   None,
   GrpcJs
 }
+
+export enum ImportStyleParameter {
+    None,
+    ES6
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import {parse} from "querystring";
 import {FileDescriptorProto} from "google-protobuf/google/protobuf/descriptor_pb";
 import {ExportEnumEntry, ExportMessageEntry} from "./ExportMap";
-import {ServiceParameter, ModeParameter} from "./parameters";
+import {ServiceParameter, ModeParameter, ImportStyleParameter} from "./parameters";
 
 export function filePathToPseudoNamespace(filePath: string): string {
   return filePath.replace(".proto", "").replace(/\//g, "_").replace(/\./g, "_").replace(/\-/g, "_") + "_pb";
@@ -182,13 +182,27 @@ export function getModeParameter(mode?: string): ModeParameter {
   }
 }
 
+export function getImportStyleParameter(importStyle?: string): ImportStyleParameter {
+  switch (importStyle) {
+    case "es6":
+      return ImportStyleParameter.ES6;
+    case undefined:
+        return ImportStyleParameter.None;
+    default:
+      throw new Error(`Unrecognised import_style parameter: ${importStyle}`);
+  }
+}
+
+
 export function getParameterEnums(parameter: string): {
   service: ServiceParameter,
-  mode: ModeParameter
+  mode: ModeParameter,
+  importStyle: ImportStyleParameter,
 } {
-  const {service, mode} = parse(parameter, ",");
+  const {service, mode, import_style} = parse(parameter, ",");
   return {
     service: getServiceParameter(service),
-    mode: getModeParameter(mode)
+    mode: getModeParameter(mode),
+    importStyle: getImportStyleParameter(import_style)
   };
 }

--- a/test/helpers/fakeGrpcTransport.ts
+++ b/test/helpers/fakeGrpcTransport.ts
@@ -23,7 +23,7 @@ function frameTrailers(trailers: grpc.Metadata): Uint8Array {
   trailers.forEach((key: string, values: string[]) => {
     asString += `${key}: ${values.join(", ")}\r\n`;
   });
-  const bytes = new Buffer(asString);
+  const bytes = Buffer.from(asString);
   const frame = new ArrayBuffer(bytes.byteLength + 5);
   const dataview = new DataView(frame, 0, 5);
   dataview.setUint32(1, bytes.length, false /* big endian */);


### PR DESCRIPTION
## Changes

* added a `import_style` parameter with the only meaningful value `es6`, it affect only `service=grpc-web` generation code. The purpose of this is generate import/export code that doesn't need browserify,webpack or similar bundler to work in browser that supports es6.
* in the test/helpers/fakeGrpcTransport.ts I just changed `new Buffer` to `Buffer.from` due this [depracation warning](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/).

I need this to use protoc-gen-ts to generate service js file usable in sveltejs + vitejs (rollup bundler).

Passing the `import_style` param like `--ts_out=service=grepc-web,import_style=es6` the `require(...)` statements are replaced by `import * as ... from ...` statements, and `exports. .... = ...` by `export {...}` statements.
 
## Verification

I checked it with a tiny sveltjs+vitejs application.
