### PR TITLE
Add type having enum values to mimic enum behavior

### DIFF
--- a/src/ts/enum.ts
+++ b/src/ts/enum.ts
@@ -14,5 +14,6 @@ export function printEnum(enumDescriptor: EnumDescriptorProto, indentLevel: numb
   printer.printLn(`}`);
   printer.printEmptyLn();
   printer.printLn(`export const ${enumDescriptor.getName()}: ${enumInterfaceName};`);
+  printer.printLn(`export type ${enumDescriptor.getName()} = ${enumInterfaceName}[keyof ${enumInterfaceName}];`);
   return printer.getOutput();
 }


### PR DESCRIPTION
## Changes

Currently tool generates interface and const to access enum-like values.
```
  export interface ResultCodeMap {
    RESULT_CODE_SUCCESS: 0;
    RESULT_CODE_PASSWORD_CHANGE_REQUIRED: 1;
    RESULT_CODE_PASSWORD_EXPIRED: 2;
    RESULT_CODE_FAILURE: 101;
  }

  export const ResultCode: ResultCodeMap;
```
Issue with such approach that you cannot use `ResultCodeMap` as function argument to restrict argument values. You need to write something like
```
function sendResultCode(code: shared_1.Historical.ResultCodeMap[keyof shared_1.Historical.ResultCodeMap]): void {
...
}
```
Then you will get compile time checks for input value. Such approach works but not user-friendly. I suggest generating alias for types like `shared_1.Historical.ResultCodeMap[keyof shared_1.Historical.ResultCodeMap]` and give it name like original enum const.

Type alias shall be
```
export type ResultCode = ResultCodeMap[keyof ResultCodeMap];
```

So function and invocation code become
```
function sendResultCode(code: shared_1.Historical.ResultCode): void {
...
}
...
sendResultCode(shared_1.Historical.ResultCode.RESULT_CODE_SUCCESS);
```

Such function and call signature naturally mimics regular enum usage.

## Verification

Tested in my own project.
